### PR TITLE
KBV-377 - persist person identity

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/address/library/domain/SessionRequest.java
+++ b/src/main/java/uk/gov/di/ipv/cri/address/library/domain/SessionRequest.java
@@ -1,9 +1,11 @@
 package uk.gov.di.ipv.cri.address.library.domain;
 
 import com.nimbusds.jwt.SignedJWT;
+import uk.gov.di.ipv.cri.address.library.domain.sharedclaims.SharedClaims;
 
 import java.net.URI;
 import java.util.Date;
+import java.util.Objects;
 
 public class SessionRequest {
     private String issuer;
@@ -17,6 +19,7 @@ public class SessionRequest {
     private URI redirectUri;
     private String state;
     private SignedJWT signedJWT;
+    private SharedClaims sharedClaims;
 
     public String getIssuer() {
         return issuer;
@@ -104,5 +107,17 @@ public class SessionRequest {
 
     public void setJwtClientId(String jwtClientId) {
         this.jwtClientId = jwtClientId;
+    }
+
+    public SharedClaims getSharedClaims() {
+        return sharedClaims;
+    }
+
+    public void setSharedClaims(SharedClaims sharedClaims) {
+        this.sharedClaims = sharedClaims;
+    }
+
+    public boolean hasSharedClaims() {
+        return Objects.nonNull(this.sharedClaims);
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/address/library/domain/personidentity/PersonAddress.java
+++ b/src/main/java/uk/gov/di/ipv/cri/address/library/domain/personidentity/PersonAddress.java
@@ -1,0 +1,96 @@
+package uk.gov.di.ipv.cri.address.library.domain.personidentity;
+
+import java.time.LocalDate;
+
+public class PersonAddress {
+    private String buildingNumber;
+    private String buildingName;
+    private String flat;
+    private String street;
+    private String townCity;
+    private String postcode;
+    private String district;
+    private PersonAddressType addressType;
+    private LocalDate dateMovedOut;
+    private LocalDate dateMovedIn;
+
+    public String getBuildingNumber() {
+        return buildingNumber;
+    }
+
+    public void setBuildingNumber(String buildingNumber) {
+        this.buildingNumber = buildingNumber;
+    }
+
+    public String getBuildingName() {
+        return buildingName;
+    }
+
+    public void setBuildingName(String buildingName) {
+        this.buildingName = buildingName;
+    }
+
+    public String getFlat() {
+        return flat;
+    }
+
+    public void setFlat(String flat) {
+        this.flat = flat;
+    }
+
+    public String getStreet() {
+        return street;
+    }
+
+    public void setStreet(String street) {
+        this.street = street;
+    }
+
+    public String getTownCity() {
+        return townCity;
+    }
+
+    public void setTownCity(String townCity) {
+        this.townCity = townCity;
+    }
+
+    public String getPostcode() {
+        return postcode;
+    }
+
+    public void setPostcode(String postcode) {
+        this.postcode = postcode;
+    }
+
+    public String getDistrict() {
+        return district;
+    }
+
+    public void setDistrict(String district) {
+        this.district = district;
+    }
+
+    public PersonAddressType getAddressType() {
+        return addressType;
+    }
+
+    public void setAddressType(PersonAddressType addressType) {
+        this.addressType = addressType;
+    }
+
+    public LocalDate getDateMovedOut() {
+        return dateMovedOut;
+    }
+
+    public void setDateMovedOut(LocalDate dateMovedOut) {
+        this.dateMovedOut = dateMovedOut;
+    }
+
+    public LocalDate getDateMovedIn() {
+        return dateMovedIn;
+    }
+
+    public void setDateMovedIn(LocalDate dateMovedIn) {
+        this.dateMovedIn = dateMovedIn;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/address/library/domain/personidentity/PersonAddressType.java
+++ b/src/main/java/uk/gov/di/ipv/cri/address/library/domain/personidentity/PersonAddressType.java
@@ -1,0 +1,6 @@
+package uk.gov.di.ipv.cri.address.library.domain.personidentity;
+
+public enum PersonAddressType {
+    CURRENT,
+    PREVIOUS
+}

--- a/src/main/java/uk/gov/di/ipv/cri/address/library/domain/personidentity/PersonIdentity.java
+++ b/src/main/java/uk/gov/di/ipv/cri/address/library/domain/personidentity/PersonIdentity.java
@@ -1,0 +1,61 @@
+package uk.gov.di.ipv.cri.address.library.domain.personidentity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PersonIdentity {
+    private String firstName;
+    private String middleNames;
+    private String surname;
+    private List<PersonAddress> addresses;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate dateOfBirth;
+
+    public PersonIdentity() {
+        this.addresses = new ArrayList<>(0);
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getMiddleNames() {
+        return middleNames;
+    }
+
+    public void setMiddleNames(String middleNames) {
+        this.middleNames = middleNames;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+
+    public LocalDate getDateOfBirth() {
+        return dateOfBirth;
+    }
+
+    public void setDateOfBirth(LocalDate dateOfBirth) {
+        this.dateOfBirth = dateOfBirth;
+    }
+
+    public List<PersonAddress> getAddresses() {
+        return addresses;
+    }
+
+    public void setAddresses(List<PersonAddress> addresses) {
+        this.addresses = addresses;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/address/library/domain/sharedclaims/Address.java
+++ b/src/main/java/uk/gov/di/ipv/cri/address/library/domain/sharedclaims/Address.java
@@ -1,59 +1,32 @@
-package uk.gov.di.ipv.cri.address.library.domain;
+package uk.gov.di.ipv.cri.address.library.domain.sharedclaims;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 
 import java.time.LocalDate;
-import java.util.Date;
-import java.util.Objects;
 import java.util.Optional;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@DynamoDbBean
-public class CanonicalAddress {
+public class Address {
     private Long uprn;
     private String organisationName;
     private String departmentName;
     private String subBuildingName;
     private String buildingNumber;
     private String buildingName;
-
-    @JsonAlias("dependentThoroughfare")
-    private String dependentThoroughfare;
-
     private String dependentStreetName;
-
-    @JsonAlias("thoroughfareName")
     private String streetName;
-
-    @JsonAlias("doubleDependentLocality")
     private String doubleDependentAddressLocality;
-
-    @JsonAlias("dependentLocality")
     private String dependentAddressLocality;
-
-    @JsonAlias("postTown")
     private String addressLocality;
-
-    @JsonAlias("postcode")
     private String postalCode;
-
-    @JsonAlias("countryCode")
     private String addressCountry;
 
-    @JsonAlias("residentFrom")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    private Date validFrom;
+    private LocalDate validFrom;
 
-    @JsonAlias("residentTo")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-    private Date validUntil;
-
-    public CanonicalAddress() {
-        // Default constructor
-    }
+    private LocalDate validUntil;
 
     public Optional<Long> getUprn() {
         return Optional.ofNullable(this.uprn);
@@ -160,22 +133,18 @@ public class CanonicalAddress {
     }
 
     public LocalDate getValidFrom() {
-        return (Objects.nonNull(validFrom))
-                ? new java.sql.Date(validFrom.getTime()).toLocalDate()
-                : null;
+        return validFrom;
     }
 
     public void setValidFrom(LocalDate validFrom) {
-        this.validFrom = java.sql.Date.valueOf(validFrom);
+        this.validFrom = validFrom;
     }
 
     public LocalDate getValidUntil() {
-        return (Objects.nonNull(validUntil))
-                ? new java.sql.Date(validUntil.getTime()).toLocalDate()
-                : null;
+        return validUntil;
     }
 
     public void setValidUntil(LocalDate validUntil) {
-        this.validUntil = java.sql.Date.valueOf(validUntil);
+        this.validUntil = validUntil;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/address/library/domain/sharedclaims/BirthDate.java
+++ b/src/main/java/uk/gov/di/ipv/cri/address/library/domain/sharedclaims/BirthDate.java
@@ -1,0 +1,13 @@
+package uk.gov.di.ipv.cri.address.library.domain.sharedclaims;
+
+public class BirthDate {
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/address/library/domain/sharedclaims/Name.java
+++ b/src/main/java/uk/gov/di/ipv/cri/address/library/domain/sharedclaims/Name.java
@@ -1,0 +1,34 @@
+package uk.gov.di.ipv.cri.address.library.domain.sharedclaims;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class Name {
+    private List<NamePart> nameParts;
+    private LocalDate validFrom;
+    private LocalDate validUntil;
+
+    public List<NamePart> getNameParts() {
+        return nameParts;
+    }
+
+    public void setNameParts(List<NamePart> nameParts) {
+        this.nameParts = nameParts;
+    }
+
+    public LocalDate getValidFrom() {
+        return validFrom;
+    }
+
+    public void setValidFrom(LocalDate validFrom) {
+        this.validFrom = validFrom;
+    }
+
+    public LocalDate getValidUntil() {
+        return validUntil;
+    }
+
+    public void setValidUntil(LocalDate validUntil) {
+        this.validUntil = validUntil;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/address/library/domain/sharedclaims/NamePart.java
+++ b/src/main/java/uk/gov/di/ipv/cri/address/library/domain/sharedclaims/NamePart.java
@@ -1,0 +1,22 @@
+package uk.gov.di.ipv.cri.address.library.domain.sharedclaims;
+
+public class NamePart {
+    private String type;
+    private String value;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/address/library/domain/sharedclaims/SharedClaims.java
+++ b/src/main/java/uk/gov/di/ipv/cri/address/library/domain/sharedclaims/SharedClaims.java
@@ -1,0 +1,51 @@
+package uk.gov.di.ipv.cri.address.library.domain.sharedclaims;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class SharedClaims {
+    @JsonProperty("name")
+    private List<Name> names;
+
+    @JsonProperty("birthDate")
+    private List<BirthDate> birthDates;
+
+    @JsonProperty("@context")
+    private List<String> context;
+
+    @JsonProperty("address")
+    private List<Address> addresses;
+
+    public List<Name> getNames() {
+        return names;
+    }
+
+    public void setNames(List<Name> names) {
+        this.names = names;
+    }
+
+    public List<BirthDate> getBirthDates() {
+        return birthDates;
+    }
+
+    public void setBirthDates(List<BirthDate> birthDates) {
+        this.birthDates = birthDates;
+    }
+
+    public List<String> getContext() {
+        return context;
+    }
+
+    public void setContext(List<String> context) {
+        this.context = context;
+    }
+
+    public List<Address> getAddresses() {
+        return addresses;
+    }
+
+    public void setAddresses(List<Address> addresses) {
+        this.addresses = addresses;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/address/library/persistence/DynamoDbEnhancedClientFactory.java
+++ b/src/main/java/uk/gov/di/ipv/cri/address/library/persistence/DynamoDbEnhancedClientFactory.java
@@ -1,0 +1,24 @@
+package uk.gov.di.ipv.cri.address.library.persistence;
+
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+public class DynamoDbEnhancedClientFactory {
+
+    private final DynamoDbEnhancedClient client;
+
+    public DynamoDbEnhancedClientFactory() {
+        DynamoDbClient dynamoDbClient =
+                DynamoDbClient.builder()
+                        .httpClient(UrlConnectionHttpClient.create())
+                        .region(Region.EU_WEST_2)
+                        .build();
+        this.client = DynamoDbEnhancedClient.builder().dynamoDbClient(dynamoDbClient).build();
+    }
+
+    public DynamoDbEnhancedClient getClient() {
+        return this.client;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/address/library/persistence/item/personidentity/PersonIdentityDateOfBirth.java
+++ b/src/main/java/uk/gov/di/ipv/cri/address/library/persistence/item/personidentity/PersonIdentityDateOfBirth.java
@@ -1,0 +1,18 @@
+package uk.gov.di.ipv.cri.address.library.persistence.item.personidentity;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+
+import java.time.LocalDate;
+
+@DynamoDbBean
+public class PersonIdentityDateOfBirth {
+    private LocalDate value;
+
+    public LocalDate getValue() {
+        return value;
+    }
+
+    public void setValue(LocalDate value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/address/library/persistence/item/personidentity/PersonIdentityItem.java
+++ b/src/main/java/uk/gov/di/ipv/cri/address/library/persistence/item/personidentity/PersonIdentityItem.java
@@ -1,0 +1,58 @@
+package uk.gov.di.ipv.cri.address.library.persistence.item.personidentity;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import uk.gov.di.ipv.cri.address.library.domain.CanonicalAddress;
+
+import java.util.List;
+import java.util.UUID;
+
+@DynamoDbBean
+public class PersonIdentityItem {
+    private UUID sessionId;
+    private List<CanonicalAddress> addresses;
+    private List<PersonIdentityName> names;
+    private List<PersonIdentityDateOfBirth> birthDates;
+    private long expiryDate;
+
+    @DynamoDbPartitionKey()
+    public UUID getSessionId() {
+        return sessionId;
+    }
+
+    public void setSessionId(UUID sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public List<CanonicalAddress> getAddresses() {
+        return addresses;
+    }
+
+    public void setAddresses(List<CanonicalAddress> addresses) {
+        this.addresses = addresses;
+    }
+
+    public List<PersonIdentityName> getNames() {
+        return names;
+    }
+
+    public void setNames(List<PersonIdentityName> names) {
+        this.names = names;
+    }
+
+    public List<PersonIdentityDateOfBirth> getBirthDates() {
+        return birthDates;
+    }
+
+    public void setBirthDates(List<PersonIdentityDateOfBirth> dateOfBirth) {
+        this.birthDates = dateOfBirth;
+    }
+
+    public long getExpiryDate() {
+        return expiryDate;
+    }
+
+    public void setExpiryDate(long expiryDate) {
+        this.expiryDate = expiryDate;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/address/library/persistence/item/personidentity/PersonIdentityName.java
+++ b/src/main/java/uk/gov/di/ipv/cri/address/library/persistence/item/personidentity/PersonIdentityName.java
@@ -1,0 +1,37 @@
+package uk.gov.di.ipv.cri.address.library.persistence.item.personidentity;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@DynamoDbBean
+public class PersonIdentityName {
+    private List<PersonIdentityNamePart> nameParts;
+    private LocalDate validFrom;
+    private LocalDate validUntil;
+
+    public List<PersonIdentityNamePart> getNameParts() {
+        return nameParts;
+    }
+
+    public void setNameParts(List<PersonIdentityNamePart> nameParts) {
+        this.nameParts = nameParts;
+    }
+
+    public LocalDate getValidFrom() {
+        return validFrom;
+    }
+
+    public void setValidFrom(LocalDate validFrom) {
+        this.validFrom = validFrom;
+    }
+
+    public LocalDate getValidUntil() {
+        return validUntil;
+    }
+
+    public void setValidUntil(LocalDate validUntil) {
+        this.validUntil = validUntil;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/address/library/persistence/item/personidentity/PersonIdentityNamePart.java
+++ b/src/main/java/uk/gov/di/ipv/cri/address/library/persistence/item/personidentity/PersonIdentityNamePart.java
@@ -1,0 +1,25 @@
+package uk.gov.di.ipv.cri.address.library.persistence.item.personidentity;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+
+@DynamoDbBean
+public class PersonIdentityNamePart {
+    private String type;
+    private String value;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/address/library/service/AuditService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/address/library/service/AuditService.java
@@ -15,13 +15,11 @@ import java.util.Date;
 public class AuditService {
     private final SqsClient sqs;
     private final String queueUrl;
-    private ConfigurationService configurationService;
     private ObjectMapper objectMapper;
 
     public AuditService(
             SqsClient sqs, ConfigurationService configurationService, ObjectMapper objectMapper) {
         this.sqs = sqs;
-        this.configurationService = configurationService;
         this.queueUrl = configurationService.getSqsAuditEventQueueUrl();
         this.objectMapper = objectMapper;
     }

--- a/src/main/java/uk/gov/di/ipv/cri/address/library/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/address/library/service/ConfigurationService.java
@@ -37,6 +37,10 @@ public class ConfigurationService {
         return ssmProvider.get(getParameterName(SSMParameterName.SESSION_TABLE_NAME));
     }
 
+    public String getPersonIdentityTableName() {
+        return ssmProvider.get(getParameterName(SSMParameterName.PERSON_IDENTITY_TABLE_NAME));
+    }
+
     public String getAddressTableName() {
         return ssmProvider.get(getParameterName(SSMParameterName.ADDRESS_TABLE_NAME));
     }
@@ -88,7 +92,8 @@ public class ConfigurationService {
         VERIFIABLE_CREDENTIAL_SIGNING_KEY_ID("verifiableCredentialKmsSigningKeyId"),
         VERIFIABLE_CREDENTIAL_ISSUER("verifiable-credential/issuer"),
         AUTH_REQUEST_KMS_ENCRYPTION_KEY_ID("AuthRequestKmsEncryptionKeyId"),
-        ADDRESS_TABLE_NAME("AddressTableName");
+        ADDRESS_TABLE_NAME("AddressTableName"),
+        PERSON_IDENTITY_TABLE_NAME("PersonIdentityTableName");
 
         public final String parameterName;
 

--- a/src/main/java/uk/gov/di/ipv/cri/address/library/service/PersonIdentityMapper.java
+++ b/src/main/java/uk/gov/di/ipv/cri/address/library/service/PersonIdentityMapper.java
@@ -1,0 +1,239 @@
+package uk.gov.di.ipv.cri.address.library.service;
+
+import uk.gov.di.ipv.cri.address.library.domain.CanonicalAddress;
+import uk.gov.di.ipv.cri.address.library.domain.personidentity.PersonAddress;
+import uk.gov.di.ipv.cri.address.library.domain.personidentity.PersonAddressType;
+import uk.gov.di.ipv.cri.address.library.domain.personidentity.PersonIdentity;
+import uk.gov.di.ipv.cri.address.library.domain.sharedclaims.Address;
+import uk.gov.di.ipv.cri.address.library.domain.sharedclaims.BirthDate;
+import uk.gov.di.ipv.cri.address.library.domain.sharedclaims.Name;
+import uk.gov.di.ipv.cri.address.library.domain.sharedclaims.SharedClaims;
+import uk.gov.di.ipv.cri.address.library.persistence.item.personidentity.PersonIdentityDateOfBirth;
+import uk.gov.di.ipv.cri.address.library.persistence.item.personidentity.PersonIdentityItem;
+import uk.gov.di.ipv.cri.address.library.persistence.item.personidentity.PersonIdentityName;
+import uk.gov.di.ipv.cri.address.library.persistence.item.personidentity.PersonIdentityNamePart;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.time.chrono.ChronoLocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+class PersonIdentityMapper {
+    private enum NamePartType {
+        GIVEN_NAME("GivenName"),
+        FAMILY_NAME("FamilyName");
+
+        private final String value;
+
+        NamePartType(String value) {
+            this.value = value;
+        }
+    }
+
+    PersonIdentityItem mapToPersonIdentityItem(SharedClaims sharedClaims) {
+        PersonIdentityItem identity = new PersonIdentityItem();
+        if (notNullAndNotEmpty(sharedClaims.getBirthDates())) {
+            identity.setBirthDates(mapBirthDates(sharedClaims.getBirthDates()));
+        }
+        if (notNullAndNotEmpty(sharedClaims.getNames())) {
+            identity.setNames(mapNames(sharedClaims.getNames()));
+        }
+        if (notNullAndNotEmpty(sharedClaims.getAddresses())) {
+            identity.setAddresses(mapAddresses(sharedClaims.getAddresses()));
+        }
+        return identity;
+    }
+
+    PersonIdentity mapToPersonIdentity(PersonIdentityItem personIdentityItem) {
+        PersonIdentity personIdentity = new PersonIdentity();
+
+        if (notNullAndNotEmpty(personIdentityItem.getNames())) {
+            PersonIdentityName personIdentityName = getCurrentName(personIdentityItem.getNames());
+            mapName(personIdentityName, personIdentity);
+        }
+
+        if (notNullAndNotEmpty(personIdentityItem.getBirthDates())) {
+            personIdentity.setDateOfBirth(personIdentityItem.getBirthDates().get(0).getValue());
+        }
+
+        if (notNullAndNotEmpty(personIdentityItem.getAddresses())) {
+            mapAddresses(personIdentityItem.getAddresses(), personIdentity);
+        }
+
+        return personIdentity;
+    }
+
+    private <T> boolean notNullAndNotEmpty(List<T> items) {
+        return Objects.nonNull(items) && !items.isEmpty();
+    }
+
+    private PersonIdentityName getCurrentName(List<PersonIdentityName> names) {
+        if (names.size() == 1) {
+            return names.get(0);
+        }
+        Optional<PersonIdentityName> currentName =
+                names.stream()
+                        .filter(
+                                n ->
+                                        Objects.nonNull(n.getValidFrom())
+                                                && isPastDateOrToday(n.getValidFrom()))
+                        .sorted(Comparator.comparing(PersonIdentityName::getValidFrom).reversed())
+                        .findFirst();
+        return currentName.orElseThrow(
+                () -> new IllegalArgumentException("Unable to find current name. Cannot map name"));
+    }
+
+    private ChronoLocalDate getDateToday() {
+        return ChronoLocalDate.from(ZonedDateTime.now());
+    }
+
+    private void mapName(PersonIdentityName name, PersonIdentity personIdentity) {
+        List<PersonIdentityNamePart> givenNameParts =
+                getNamePartsByType(name, NamePartType.GIVEN_NAME);
+        List<PersonIdentityNamePart> familyNameParts =
+                getNamePartsByType(name, NamePartType.FAMILY_NAME);
+
+        if (givenNameParts.isEmpty()) {
+            throw new IllegalArgumentException("No given names found. Cannot map firstname");
+        }
+        if (familyNameParts.isEmpty()) {
+            throw new IllegalArgumentException("No family names found. Cannot map surname");
+        } else if (familyNameParts.size() > 1) {
+            throw new IllegalArgumentException("More than 1 family name found. Cannot map surname");
+        }
+        personIdentity.setFirstName(givenNameParts.get(0).getValue());
+        if (givenNameParts.size() > 1) {
+            personIdentity.setMiddleNames(
+                    String.join(
+                            " ",
+                            givenNameParts.subList(1, givenNameParts.size()).stream()
+                                    .map(PersonIdentityNamePart::getValue)
+                                    .toArray(String[]::new)));
+        }
+        personIdentity.setSurname(familyNameParts.get(0).getValue());
+    }
+
+    private List<PersonIdentityNamePart> getNamePartsByType(
+            PersonIdentityName name, NamePartType namePartType) {
+        return name.getNameParts().stream()
+                .filter(np -> np.getType().equals(namePartType.value))
+                .collect(Collectors.toList());
+    }
+
+    private void mapAddresses(
+            List<CanonicalAddress> sourceAddresses, PersonIdentity personIdentity) {
+        List<PersonAddress> personAddresses =
+                sourceAddresses.stream()
+                        .map(
+                                sourceAddress -> {
+                                    PersonAddress personAddress = new PersonAddress();
+                                    personAddress.setBuildingNumber(
+                                            sourceAddress.getBuildingNumber());
+                                    personAddress.setBuildingName(sourceAddress.getBuildingName());
+                                    personAddress.setStreet(sourceAddress.getStreetName());
+                                    personAddress.setTownCity(sourceAddress.getAddressLocality());
+                                    personAddress.setPostcode(sourceAddress.getPostalCode());
+                                    personAddress.setAddressType(getAddressType(sourceAddress));
+                                    personAddress.setDateMovedIn(sourceAddress.getValidFrom());
+                                    personAddress.setDateMovedOut(sourceAddress.getValidUntil());
+                                    return personAddress;
+                                })
+                        .collect(Collectors.toList());
+
+        personIdentity.setAddresses(personAddresses);
+    }
+
+    private boolean isPastDate(LocalDate input) {
+        return input.compareTo(getDateToday()) < 0;
+    }
+
+    private boolean isPastDateOrToday(LocalDate input) {
+        return input.compareTo(getDateToday()) <= 0;
+    }
+
+    private PersonAddressType getAddressType(CanonicalAddress address) {
+        if (Objects.nonNull(address.getValidUntil()) && isPastDate(address.getValidUntil())) {
+            return PersonAddressType.PREVIOUS;
+        }
+
+        if (Objects.isNull(address.getValidUntil())
+                && (Objects.nonNull(address.getValidFrom())
+                        && isPastDateOrToday(address.getValidFrom()))) {
+            return PersonAddressType.CURRENT;
+        }
+
+        return null;
+    }
+
+    private List<PersonIdentityDateOfBirth> mapBirthDates(List<BirthDate> birthDates) {
+        return birthDates.stream()
+                .map(
+                        bd -> {
+                            PersonIdentityDateOfBirth dob = new PersonIdentityDateOfBirth();
+                            dob.setValue(LocalDate.parse(bd.getValue()));
+                            return dob;
+                        })
+                .collect(Collectors.toList());
+    }
+
+    private List<PersonIdentityName> mapNames(List<Name> names) {
+        return names.stream()
+                .map(
+                        n -> {
+                            PersonIdentityName name = new PersonIdentityName();
+                            name.setValidFrom(n.getValidFrom());
+                            name.setValidUntil(n.getValidUntil());
+                            if (notNullAndNotEmpty(n.getNameParts())) {
+                                name.setNameParts(
+                                        n.getNameParts().stream()
+                                                .map(
+                                                        np -> {
+                                                            PersonIdentityNamePart namePart =
+                                                                    new PersonIdentityNamePart();
+                                                            namePart.setType(np.getType());
+                                                            namePart.setValue(np.getValue());
+                                                            return namePart;
+                                                        })
+                                                .collect(Collectors.toList()));
+                            }
+                            return name;
+                        })
+                .collect(Collectors.toList());
+    }
+
+    private List<CanonicalAddress> mapAddresses(List<Address> addresses) {
+        return addresses.stream()
+                .map(
+                        a -> {
+                            CanonicalAddress canonicalAddress = new CanonicalAddress();
+                            canonicalAddress.setUprn(a.getUprn().orElse(null));
+                            canonicalAddress.setOrganisationName(a.getOrganisationName());
+                            canonicalAddress.setDepartmentName(a.getDepartmentName());
+                            canonicalAddress.setSubBuildingName(a.getSubBuildingName());
+                            canonicalAddress.setBuildingNumber(a.getBuildingNumber());
+                            canonicalAddress.setBuildingName(a.getBuildingName());
+                            canonicalAddress.setDependentStreetName(a.getDependentStreetName());
+                            canonicalAddress.setStreetName(a.getStreetName());
+                            canonicalAddress.setAddressCountry(a.getAddressCountry());
+                            canonicalAddress.setPostalCode(a.getPostalCode());
+                            if (Objects.nonNull(a.getValidFrom())) {
+                                canonicalAddress.setValidFrom(a.getValidFrom());
+                            }
+                            if (Objects.nonNull(a.getValidUntil())) {
+                                canonicalAddress.setValidUntil(a.getValidUntil());
+                            }
+                            canonicalAddress.setAddressLocality(a.getAddressLocality());
+                            canonicalAddress.setDependentAddressLocality(
+                                    a.getDependentAddressLocality());
+                            canonicalAddress.setDoubleDependentAddressLocality(
+                                    a.getDoubleDependentAddressLocality());
+
+                            return canonicalAddress;
+                        })
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/address/library/service/PersonIdentityService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/address/library/service/PersonIdentityService.java
@@ -1,0 +1,60 @@
+package uk.gov.di.ipv.cri.address.library.service;
+
+import uk.gov.di.ipv.cri.address.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.cri.address.library.domain.personidentity.PersonIdentity;
+import uk.gov.di.ipv.cri.address.library.domain.sharedclaims.SharedClaims;
+import uk.gov.di.ipv.cri.address.library.persistence.DataStore;
+import uk.gov.di.ipv.cri.address.library.persistence.DynamoDbEnhancedClientFactory;
+import uk.gov.di.ipv.cri.address.library.persistence.item.personidentity.PersonIdentityItem;
+
+import java.time.Clock;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+public class PersonIdentityService {
+    private final PersonIdentityMapper personIdentityMapper;
+    private final ConfigurationService configurationService;
+    private final DataStore<PersonIdentityItem> personIdentityDataStore;
+    private final Clock clock;
+
+    @ExcludeFromGeneratedCoverageReport
+    public PersonIdentityService() {
+        this.configurationService = new ConfigurationService();
+        this.personIdentityMapper = new PersonIdentityMapper();
+        this.personIdentityDataStore =
+                new DataStore<>(
+                        configurationService.getPersonIdentityTableName(),
+                        PersonIdentityItem.class,
+                        new DynamoDbEnhancedClientFactory().getClient());
+        this.clock = Clock.systemUTC();
+    }
+
+    public PersonIdentityService(
+            PersonIdentityMapper personIdentityMapper,
+            ConfigurationService configurationService,
+            DataStore<PersonIdentityItem> personIdentityDataStore,
+            Clock clock) {
+        this.personIdentityMapper = personIdentityMapper;
+        this.configurationService = configurationService;
+        this.personIdentityDataStore = personIdentityDataStore;
+        this.clock = clock;
+    }
+
+    public void savePersonIdentity(UUID sessionId, SharedClaims sharedClaims) {
+        PersonIdentityItem personIdentityItem =
+                personIdentityMapper.mapToPersonIdentityItem(sharedClaims);
+        personIdentityItem.setSessionId(sessionId);
+        personIdentityItem.setExpiryDate(
+                clock.instant()
+                        .plus(configurationService.getSessionTtl(), ChronoUnit.SECONDS)
+                        .getEpochSecond());
+
+        this.personIdentityDataStore.create(personIdentityItem);
+    }
+
+    public PersonIdentity getPersonIdentity(UUID sessionId) {
+        PersonIdentityItem personIdentityItem =
+                this.personIdentityDataStore.getItem(String.valueOf(sessionId));
+        return personIdentityMapper.mapToPersonIdentity(personIdentityItem);
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/address/library/service/SessionService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/address/library/service/SessionService.java
@@ -6,6 +6,7 @@ import uk.gov.di.ipv.cri.address.library.domain.SessionRequest;
 import uk.gov.di.ipv.cri.address.library.exception.SessionExpiredException;
 import uk.gov.di.ipv.cri.address.library.exception.SessionNotFoundException;
 import uk.gov.di.ipv.cri.address.library.persistence.DataStore;
+import uk.gov.di.ipv.cri.address.library.persistence.DynamoDbEnhancedClientFactory;
 import uk.gov.di.ipv.cri.address.library.persistence.item.SessionItem;
 import uk.gov.di.ipv.cri.address.library.util.ListUtil;
 
@@ -26,7 +27,7 @@ public class SessionService {
                 new DataStore<>(
                         configurationService.getSessionTableName(),
                         SessionItem.class,
-                        DataStore.getClient());
+                        new DynamoDbEnhancedClientFactory().getClient());
         this.clock = Clock.systemUTC();
         this.listUtil = new ListUtil();
     }
@@ -42,8 +43,7 @@ public class SessionService {
         this.listUtil = listUtil;
     }
 
-    public UUID createAndSaveAddressSession(SessionRequest sessionRequest) {
-
+    public UUID saveSession(SessionRequest sessionRequest) {
         SessionItem sessionItem = new SessionItem();
         sessionItem.setExpiryDate(
                 clock.instant()

--- a/src/main/java/uk/gov/di/ipv/cri/address/library/util/EventProbe.java
+++ b/src/main/java/uk/gov/di/ipv/cri/address/library/util/EventProbe.java
@@ -8,6 +8,7 @@ import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.lambda.powertools.metrics.MetricsUtils;
 
 import java.util.Map;
+import java.util.Objects;
 
 public class EventProbe {
 
@@ -16,13 +17,10 @@ public class EventProbe {
 
     public EventProbe log(Level level, Exception e) {
         LOGGER.log(level, e);
-        if (level == Level.ERROR) {
-            if (e.getCause() != null) {
-                LOGGER.log(level, e.getCause());
-
-                if (e.getCause().getCause() != null) {
-                    LOGGER.log(level, e.getCause().getCause());
-                }
+        if (level == Level.ERROR && Objects.nonNull(e.getCause())) {
+            LOGGER.log(level, e.getCause());
+            if (Objects.nonNull(e.getCause().getCause())) {
+                LOGGER.log(level, e.getCause().getCause());
             }
         }
         return this;

--- a/src/test/java/uk/gov/di/ipv/cri/address/library/service/PersonIdentityMapperTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/address/library/service/PersonIdentityMapperTest.java
@@ -1,0 +1,225 @@
+package uk.gov.di.ipv.cri.address.library.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.address.library.domain.CanonicalAddress;
+import uk.gov.di.ipv.cri.address.library.domain.personidentity.PersonAddress;
+import uk.gov.di.ipv.cri.address.library.domain.personidentity.PersonAddressType;
+import uk.gov.di.ipv.cri.address.library.domain.personidentity.PersonIdentity;
+import uk.gov.di.ipv.cri.address.library.domain.sharedclaims.Address;
+import uk.gov.di.ipv.cri.address.library.domain.sharedclaims.BirthDate;
+import uk.gov.di.ipv.cri.address.library.domain.sharedclaims.Name;
+import uk.gov.di.ipv.cri.address.library.domain.sharedclaims.NamePart;
+import uk.gov.di.ipv.cri.address.library.domain.sharedclaims.SharedClaims;
+import uk.gov.di.ipv.cri.address.library.persistence.item.personidentity.PersonIdentityDateOfBirth;
+import uk.gov.di.ipv.cri.address.library.persistence.item.personidentity.PersonIdentityItem;
+import uk.gov.di.ipv.cri.address.library.persistence.item.personidentity.PersonIdentityName;
+import uk.gov.di.ipv.cri.address.library.persistence.item.personidentity.PersonIdentityNamePart;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@ExtendWith(MockitoExtension.class)
+class PersonIdentityMapperTest {
+    private static final LocalDate TODAY = LocalDate.now();
+    private PersonIdentityMapper personIdentityMapper;
+
+    @BeforeEach()
+    void setup() {
+        this.personIdentityMapper = new PersonIdentityMapper();
+    }
+
+    @Test
+    void shouldMapToPersonIdentity() {
+        PersonIdentityNamePart firstNamePart = new PersonIdentityNamePart();
+        firstNamePart.setType("GivenName");
+        firstNamePart.setValue("Jon");
+        PersonIdentityNamePart surnamePart = new PersonIdentityNamePart();
+        surnamePart.setType("FamilyName");
+        surnamePart.setValue("Smith");
+        PersonIdentityName name = new PersonIdentityName();
+        name.setNameParts(List.of(firstNamePart, surnamePart));
+
+        PersonIdentityDateOfBirth birthDate = new PersonIdentityDateOfBirth();
+        birthDate.setValue(LocalDate.of(1980, 10, 20));
+
+        CanonicalAddress address = new CanonicalAddress();
+        address.setBuildingNumber("buildingNum");
+        address.setBuildingName("buildingName");
+        address.setStreetName("street");
+        address.setAddressLocality("locality");
+        address.setPostalCode("postcode");
+        address.setValidFrom(TODAY);
+
+        PersonIdentityItem testPersonIdentityItem = new PersonIdentityItem();
+        testPersonIdentityItem.setNames(List.of(name));
+        testPersonIdentityItem.setBirthDates(List.of(birthDate));
+        testPersonIdentityItem.setAddresses(List.of(address));
+
+        PersonIdentity mappedPersonIdentity =
+                this.personIdentityMapper.mapToPersonIdentity(testPersonIdentityItem);
+
+        assertEquals(firstNamePart.getValue(), mappedPersonIdentity.getFirstName());
+        assertEquals(surnamePart.getValue(), mappedPersonIdentity.getSurname());
+        assertEquals(birthDate.getValue(), mappedPersonIdentity.getDateOfBirth());
+        PersonAddress mappedAddress = mappedPersonIdentity.getAddresses().get(0);
+        assertEquals(address.getBuildingName(), mappedAddress.getBuildingName());
+        assertEquals(address.getBuildingNumber(), mappedAddress.getBuildingNumber());
+        assertEquals(address.getStreetName(), mappedAddress.getStreet());
+        assertEquals(address.getAddressLocality(), mappedAddress.getTownCity());
+        assertEquals(address.getPostalCode(), mappedAddress.getPostcode());
+        assertEquals(address.getValidFrom(), mappedAddress.getDateMovedIn());
+        assertEquals(PersonAddressType.CURRENT, mappedAddress.getAddressType());
+    }
+
+    @Test
+    void shouldMapMiddleNames() {
+        PersonIdentityNamePart firstNamePart = new PersonIdentityNamePart();
+        firstNamePart.setType("GivenName");
+        firstNamePart.setValue("Jon");
+        PersonIdentityNamePart secondNamePart = new PersonIdentityNamePart();
+        secondNamePart.setType("GivenName");
+        secondNamePart.setValue("Henry");
+        PersonIdentityNamePart thirdNamePart = new PersonIdentityNamePart();
+        thirdNamePart.setType("GivenName");
+        thirdNamePart.setValue("Jack");
+        PersonIdentityNamePart surnamePart = new PersonIdentityNamePart();
+        surnamePart.setType("FamilyName");
+        surnamePart.setValue("Smith");
+        PersonIdentityName name = new PersonIdentityName();
+        name.setNameParts(List.of(firstNamePart, secondNamePart, thirdNamePart, surnamePart));
+        PersonIdentityItem testPersonIdentityItem = new PersonIdentityItem();
+        testPersonIdentityItem.setNames(List.of(name));
+
+        PersonIdentity mappedPersonIdentity =
+                this.personIdentityMapper.mapToPersonIdentity(testPersonIdentityItem);
+
+        assertEquals(firstNamePart.getValue(), mappedPersonIdentity.getFirstName());
+        assertEquals(
+                secondNamePart.getValue() + " " + thirdNamePart.getValue(),
+                mappedPersonIdentity.getMiddleNames());
+        assertEquals(surnamePart.getValue(), mappedPersonIdentity.getSurname());
+        assertNull(mappedPersonIdentity.getDateOfBirth());
+        assertEquals(0, mappedPersonIdentity.getAddresses().size());
+    }
+
+    @Test
+    void shouldMapCurrentName() {
+        LocalDate validityDate = LocalDate.of(2011, 5, 20);
+        PersonIdentityNamePart firstNamePart = new PersonIdentityNamePart();
+        firstNamePart.setType("GivenName");
+        firstNamePart.setValue("Sarah");
+        PersonIdentityNamePart surnamePart = new PersonIdentityNamePart();
+        surnamePart.setType("FamilyName");
+        surnamePart.setValue("Jones");
+        PersonIdentityName previousName = new PersonIdentityName();
+        previousName.setNameParts(List.of(firstNamePart, surnamePart));
+        previousName.setValidFrom(LocalDate.of(1980, 5, 24));
+        previousName.setValidUntil(validityDate);
+
+        PersonIdentityNamePart currentFirstNamePart = new PersonIdentityNamePart();
+        currentFirstNamePart.setType("GivenName");
+        currentFirstNamePart.setValue("Sarah");
+        PersonIdentityNamePart currentSurnamePart = new PersonIdentityNamePart();
+        currentSurnamePart.setType("FamilyName");
+        currentSurnamePart.setValue("Young");
+        PersonIdentityName currentName = new PersonIdentityName();
+        currentName.setNameParts(List.of(currentFirstNamePart, currentSurnamePart));
+        currentName.setValidFrom(validityDate);
+
+        PersonIdentityItem testPersonIdentityItem = new PersonIdentityItem();
+        testPersonIdentityItem.setNames(List.of(previousName, currentName));
+
+        PersonIdentity mappedPersonIdentity =
+                personIdentityMapper.mapToPersonIdentity(testPersonIdentityItem);
+
+        assertEquals(currentFirstNamePart.getValue(), mappedPersonIdentity.getFirstName());
+        assertEquals(currentSurnamePart.getValue(), mappedPersonIdentity.getSurname());
+    }
+
+    @Test
+    void shouldMapCurrentAndPreviousAddresses() {
+        // address
+        CanonicalAddress address = new CanonicalAddress();
+        address.setBuildingNumber("buildingNum");
+        address.setStreetName("street");
+        address.setPostalCode("postcode");
+        address.setValidFrom(TODAY);
+
+        CanonicalAddress previousAddress = new CanonicalAddress();
+        previousAddress.setBuildingNumber("buildingNum");
+        previousAddress.setStreetName("street");
+        previousAddress.setPostalCode("postcode");
+        previousAddress.setValidUntil(TODAY.minus(1L, ChronoUnit.DAYS));
+
+        PersonIdentityItem testPersonIdentityItem = new PersonIdentityItem();
+        testPersonIdentityItem.setAddresses(List.of(address, previousAddress));
+
+        PersonIdentity mappedPersonIdentity =
+                personIdentityMapper.mapToPersonIdentity(testPersonIdentityItem);
+
+        assertEquals(2, mappedPersonIdentity.getAddresses().size());
+        assertEquals(
+                PersonAddressType.CURRENT,
+                mappedPersonIdentity.getAddresses().get(0).getAddressType());
+        assertEquals(
+                PersonAddressType.PREVIOUS,
+                mappedPersonIdentity.getAddresses().get(1).getAddressType());
+    }
+
+    @Test
+    void shouldMapSharedClaimsToPersonIdentityItem() {
+        SharedClaims sharedClaims = new SharedClaims();
+
+        NamePart firstNamePart = new NamePart();
+        firstNamePart.setType("GivenName");
+        firstNamePart.setValue("Jon");
+        NamePart surnamePart = new NamePart();
+        surnamePart.setType("FamilyName");
+        surnamePart.setValue("Smith");
+        Name name = new Name();
+        name.setValidFrom(TODAY);
+        name.setNameParts(List.of(firstNamePart, surnamePart));
+        sharedClaims.setNames(List.of(name));
+
+        BirthDate birthDate = new BirthDate();
+        birthDate.setValue(LocalDate.of(1984, 6, 27).toString());
+        sharedClaims.setBirthDates(List.of(birthDate));
+
+        Address address = new Address();
+        address.setBuildingNumber("buildingNum");
+        address.setBuildingName("buildingName");
+        address.setStreetName("street");
+        address.setAddressLocality("locality");
+        address.setPostalCode("postcode");
+        address.setValidFrom(TODAY);
+        sharedClaims.setAddresses(List.of(address));
+
+        PersonIdentityItem mappedPersonIdentityItem =
+                personIdentityMapper.mapToPersonIdentityItem(sharedClaims);
+
+        PersonIdentityName mappedName = mappedPersonIdentityItem.getNames().get(0);
+        CanonicalAddress mappedAddress = mappedPersonIdentityItem.getAddresses().get(0);
+        assertEquals(name.getValidFrom(), mappedName.getValidFrom());
+        assertEquals(firstNamePart.getValue(), mappedName.getNameParts().get(0).getValue());
+        assertEquals(firstNamePart.getType(), mappedName.getNameParts().get(0).getType());
+        assertEquals(surnamePart.getValue(), mappedName.getNameParts().get(1).getValue());
+        assertEquals(surnamePart.getType(), mappedName.getNameParts().get(1).getType());
+        assertEquals(
+                LocalDate.parse(birthDate.getValue()),
+                mappedPersonIdentityItem.getBirthDates().get(0).getValue());
+        assertEquals(address.getAddressLocality(), mappedAddress.getAddressLocality());
+        assertEquals(address.getBuildingName(), mappedAddress.getBuildingName());
+        assertEquals(address.getBuildingNumber(), mappedAddress.getBuildingNumber());
+        assertEquals(address.getStreetName(), mappedAddress.getStreetName());
+        assertEquals(address.getPostalCode(), mappedAddress.getPostalCode());
+        assertEquals(TODAY, mappedAddress.getValidFrom());
+        assertNull(mappedAddress.getValidUntil());
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/cri/address/library/service/PersonIdentityServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/address/library/service/PersonIdentityServiceTest.java
@@ -1,0 +1,71 @@
+package uk.gov.di.ipv.cri.address.library.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.address.library.domain.personidentity.PersonIdentity;
+import uk.gov.di.ipv.cri.address.library.domain.sharedclaims.SharedClaims;
+import uk.gov.di.ipv.cri.address.library.persistence.DataStore;
+import uk.gov.di.ipv.cri.address.library.persistence.item.personidentity.PersonIdentityItem;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PersonIdentityServiceTest {
+    private static final UUID TEST_SESSION_ID = UUID.randomUUID();
+    @Mock private PersonIdentityMapper mockPersonIdentityMapper;
+    @Mock private ConfigurationService mockConfigurationService;
+    @Mock private DataStore<PersonIdentityItem> mockPersonIdentityDataStore;
+    @Mock private Clock mockClock;
+    @InjectMocks private PersonIdentityService personIdentityService;
+
+    @Test
+    void shouldSavePersonIdentity() {
+        long sessionTtl = 30L;
+        SharedClaims testSharedClaims = new SharedClaims();
+        PersonIdentityItem testPersonIdentityItem = mock(PersonIdentityItem.class);
+        Instant instant = Instant.now();
+
+        when(mockPersonIdentityMapper.mapToPersonIdentityItem(testSharedClaims))
+                .thenReturn(testPersonIdentityItem);
+        when(mockConfigurationService.getSessionTtl()).thenReturn(sessionTtl);
+        when(mockClock.instant()).thenReturn(instant);
+
+        personIdentityService.savePersonIdentity(TEST_SESSION_ID, testSharedClaims);
+
+        verify(mockPersonIdentityMapper).mapToPersonIdentityItem(testSharedClaims);
+        verify(testPersonIdentityItem).setSessionId(TEST_SESSION_ID);
+        verify(mockConfigurationService).getSessionTtl();
+        verify(testPersonIdentityItem)
+                .setExpiryDate(instant.plus(sessionTtl, ChronoUnit.SECONDS).getEpochSecond());
+        verify(mockPersonIdentityDataStore).create(testPersonIdentityItem);
+    }
+
+    @Test
+    void shouldGetPersonIdentity() {
+        PersonIdentityItem testPersonIdentityItem = new PersonIdentityItem();
+        PersonIdentity testPersonIdentity = new PersonIdentity();
+
+        when(mockPersonIdentityDataStore.getItem(String.valueOf(TEST_SESSION_ID)))
+                .thenReturn(testPersonIdentityItem);
+        when(mockPersonIdentityMapper.mapToPersonIdentity(testPersonIdentityItem))
+                .thenReturn(testPersonIdentity);
+
+        PersonIdentity retrievedPersonIdentity =
+                personIdentityService.getPersonIdentity(TEST_SESSION_ID);
+
+        verify(mockPersonIdentityDataStore).getItem(String.valueOf(TEST_SESSION_ID));
+        verify(mockPersonIdentityMapper).mapToPersonIdentity(testPersonIdentityItem);
+        assertEquals(testPersonIdentity, retrievedPersonIdentity);
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/cri/address/library/service/SessionServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/address/library/service/SessionServiceTest.java
@@ -67,7 +67,7 @@ class SessionServiceTest {
                 .thenReturn(URI.create("https://www.example.com/callback"));
         when(sessionRequest.getSubject()).thenReturn("a subject");
 
-        sessionService.createAndSaveAddressSession(sessionRequest);
+        sessionService.saveSession(sessionRequest);
         verify(mockDataStore).create(sessionItemArgumentCaptor.capture());
         SessionItem capturedValue = sessionItemArgumentCaptor.getValue();
         assertNotNull(capturedValue.getSessionId());


### PR DESCRIPTION
Add PersonIdentityService to enable user PII to be persisted to dynamo db and retrieved in an appropriate shape for sending to the third party knowledge-based-verification and fraud APIs.

[KBV-377](https://govukverify.atlassian.net/browse/KBV-377)