### PR TITLE
BAU Fix KMS  signature padding

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=11.0.14-zulu

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/KMSSigner.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/KMSSigner.java
@@ -16,7 +16,6 @@ import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverage
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Base64;
 import java.util.Objects;
 import java.util.Set;
 
@@ -24,7 +23,6 @@ import static com.nimbusds.jose.JWSAlgorithm.ES256;
 
 public class KMSSigner implements JWSSigner {
 
-    private static final Base64.Encoder b64UrlEncoder = Base64.getUrlEncoder();
     private final KmsClient kmsClient;
     private final JCAContext jcaContext = new JCAContext();
     private final String keyId;
@@ -62,7 +60,7 @@ public class KMSSigner implements JWSSigner {
 
         SignResponse signResponse = kmsClient.sign(signRequest);
 
-        return new Base64URL(b64UrlEncoder.encodeToString(signResponse.signature().asByteArray()));
+        return Base64URL.encode(signResponse.signature().asByteArray());
     }
 
     @Override


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

(This is a copy of https://github.com/alphagov/di-ipv-cri-uk-passport-back/pull/133)

Use nimbus's Base64URL.encode() function to base64URL encode the
signature bytes received from KMS.

The encoder offered by java.util via `Base64.getUrlEncoder()` does not
strip padding as we expected. It's java docs reference Table 2 of RFC
4648, which is a bit vague about the handling of padding:

"This encoding is technically identical to the previous one, except
   for the 62:nd and 63:rd alphabet character, as indicated in Table 2."

As a result we were occasionally including an `=` on the end of our
serialized JWT strings. The nimbus lib is gracious enough to handle
these and still verify the signatures correctly, but it was causing
issues in SPOT. So here's a fix.

