### PR TITLE
KBV-395 Fix to avoid errors when parsing NameParts with unexpected properties

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/sharedclaims/NamePart.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/sharedclaims/NamePart.java
@@ -1,5 +1,8 @@
 package uk.gov.di.ipv.cri.common.library.domain.sharedclaims;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class NamePart {
     private String type;
     private String value;

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/domain/sharedclaims/NamePartTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/domain/sharedclaims/NamePartTest.java
@@ -1,0 +1,27 @@
+package uk.gov.di.ipv.cri.common.library.domain.sharedclaims;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class NamePartTest {
+
+    @Test
+    void testThatUnknownFieldsAreIgnored() throws IOException {
+        String invalidJSON =
+                "{\n"
+                        + "  \"type\": \"a type\",\n"
+                        + "  \"validUntil\": 12345\n"
+                        + // validUntil is not a property
+                        "}";
+        NamePart namePart =
+                new ObjectMapper()
+                        .readValue(invalidJSON.getBytes(StandardCharsets.UTF_8), NamePart.class);
+        assertThat(namePart.getType(), equalTo("a type"));
+    }
+}


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes


Fix to avoid errors in CRIs when parsing NameParts with unexpected properties.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-395](https://govukverify.atlassian.net/browse/KBV-395)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed
