### PR TITLE
[KBV-106] Add new event types

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEventTypes.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEventTypes.java
@@ -6,6 +6,6 @@ public enum AuditEventTypes {
     IPV_ADDRESS_CRI_VC_ISSUED, // When the final VC is created in the issue credential lambda
 
     IPV_KBV_CRI_START, // Before a session is written to the Session table
-    IPV_KBV_CRI_REQUEST_SENT, // When an address is added in the PUT /address API call
+    IPV_KBV_CRI_REQUEST_SENT, // When KBV answers are submitted
     IPV_KBV_CRI_VC_ISSUED // When the final VC is created in the issue credential lambda
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEventTypes.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEventTypes.java
@@ -3,5 +3,9 @@ package uk.gov.di.ipv.cri.common.library.domain;
 public enum AuditEventTypes {
     IPV_ADDRESS_CRI_START, // Before a session is written to the Session table
     IPV_ADDRESS_CRI_REQUEST_SENT, // When an address is added in the PUT /address API call
-    IPV_ADDRESS_CRI_VC_ISSUED // When the final VC is created in the issue credential lambda
+    IPV_ADDRESS_CRI_VC_ISSUED, // When the final VC is created in the issue credential lambda
+
+    IPV_KBV_CRI_START, // Before a session is written to the Session table
+    IPV_KBV_CRI_REQUEST_SENT, // When an address is added in the PUT /address API call
+    IPV_KBV_CRI_VC_ISSUED // When the final VC is created in the issue credential lambda
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Added new event types for the new KBV auditing

### Why did it change

The audit service currently sends events using these constants.
This gets it working at the moment, however this will need to be revisited

### Issue tracking
- [KBV-106](https://govukverify.atlassian.net/browse/KBV-106)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed
