### PR TITLE
BAU - ConfigurationService Refactor - Commence removal of non-common methods

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationService.java
@@ -3,29 +3,29 @@ package uk.gov.di.ipv.cri.common.library.service;
 import software.amazon.lambda.powertools.parameters.ParamManager;
 import software.amazon.lambda.powertools.parameters.SSMProvider;
 import software.amazon.lambda.powertools.parameters.SecretsProvider;
+import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 
 import java.net.URI;
+import java.time.Clock;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
 public class ConfigurationService {
 
-    private static final long DEFAULT_SESSION_ADDRESS_TTL_IN_SECS = 172800L;
+    private static final String PARAMETER_NAME_FORMAT = "/%s/%s";
+    private static final long DEFAULT_SESSION_TTL_IN_SECS = 172800L;
     private static final long DEFAULT_BEARER_TOKEN_TTL_IN_SECS = 3600L;
     private static final long DEFAULT_MAXIMUM_JWT_TTL = 3600L;
     private final SSMProvider ssmProvider;
     private final SecretsProvider secretsProvider;
     private final String parameterPrefix;
+    private final Clock clock;
 
-    public ConfigurationService(
-            SSMProvider ssmProvider, SecretsProvider secretsProvider, String parameterPrefix) {
-        this.ssmProvider = ssmProvider;
-        this.secretsProvider = secretsProvider;
-        this.parameterPrefix = parameterPrefix;
-    }
-
+    @ExcludeFromGeneratedCoverageReport
     public ConfigurationService() {
+        this.clock = Clock.systemUTC();
         this.ssmProvider = ParamManager.getSsmProvider();
         this.secretsProvider = ParamManager.getSecretsProvider();
         this.parameterPrefix =
@@ -33,25 +33,42 @@ public class ConfigurationService {
                         System.getenv("AWS_STACK_NAME"), "env var AWS_STACK_NAME required");
     }
 
-    public String getSessionTableName() {
-        return ssmProvider.get(getParameterName(SSMParameterName.SESSION_TABLE_NAME));
-    }
-
-    public String getPersonIdentityTableName() {
-        return ssmProvider.get(getParameterName(SSMParameterName.PERSON_IDENTITY_TABLE_NAME));
+    public ConfigurationService(
+            SSMProvider ssmProvider,
+            SecretsProvider secretsProvider,
+            String parameterPrefix,
+            Clock clock) {
+        this.ssmProvider = ssmProvider;
+        this.secretsProvider = secretsProvider;
+        this.parameterPrefix = parameterPrefix;
+        this.clock = clock;
     }
 
     public String getAddressTableName() {
         return ssmProvider.get(getParameterName(SSMParameterName.ADDRESS_TABLE_NAME));
     }
 
+    public String getParameterValue(String parameterName) {
+        return ssmProvider.get(
+                String.format(PARAMETER_NAME_FORMAT, parameterPrefix, parameterName));
+    }
+
+    public String getSecretValue(String secretName) {
+        return secretsProvider.get(
+                String.format(PARAMETER_NAME_FORMAT, parameterPrefix, secretName));
+    }
+
     public long getSessionTtl() {
         return Optional.ofNullable(ssmProvider.get(getParameterName(SSMParameterName.SESSION_TTL)))
                 .map(Long::valueOf)
-                .orElse(DEFAULT_SESSION_ADDRESS_TTL_IN_SECS);
+                .orElse(DEFAULT_SESSION_TTL_IN_SECS);
     }
 
-    public String getParameterName(SSMParameterName parameterName) {
+    public long getSessionExpirationEpoch() {
+        return clock.instant().plus(getSessionTtl(), ChronoUnit.SECONDS).getEpochSecond();
+    }
+
+    private String getParameterName(SSMParameterName parameterName) {
         return String.format("/%s/%s", parameterPrefix, parameterName.parameterName);
     }
 
@@ -83,7 +100,6 @@ public class ConfigurationService {
     }
 
     public enum SSMParameterName {
-        SESSION_TABLE_NAME("SessionTableName"),
         SESSION_TTL("SessionTtl"),
         ORDNANCE_SURVEY_API_KEY("OrdnanceSurveyAPIKey"),
         ORDNANCE_SURVEY_API_URL("OrdnanceSurveyAPIURL"),
@@ -92,8 +108,7 @@ public class ConfigurationService {
         VERIFIABLE_CREDENTIAL_SIGNING_KEY_ID("verifiableCredentialKmsSigningKeyId"),
         VERIFIABLE_CREDENTIAL_ISSUER("verifiable-credential/issuer"),
         AUTH_REQUEST_KMS_ENCRYPTION_KEY_ID("AuthRequestKmsEncryptionKeyId"),
-        ADDRESS_TABLE_NAME("AddressTableName"),
-        PERSON_IDENTITY_TABLE_NAME("PersonIdentityTableName");
+        ADDRESS_TABLE_NAME("AddressTableName");
 
         public final String parameterName;
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
@@ -11,10 +11,10 @@ import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
 import uk.gov.di.ipv.cri.common.library.util.ListUtil;
 
 import java.time.Clock;
-import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
 public class SessionService {
+    private static final String SESSION_TABLE_PARAM_NAME = "SessionTableName";
     private final ConfigurationService configurationService;
     private final DataStore<SessionItem> dataStore;
     private final ListUtil listUtil;
@@ -25,7 +25,7 @@ public class SessionService {
         this.configurationService = new ConfigurationService();
         this.dataStore =
                 new DataStore<>(
-                        configurationService.getSessionTableName(),
+                        configurationService.getParameterValue(SESSION_TABLE_PARAM_NAME),
                         SessionItem.class,
                         new DynamoDbEnhancedClientFactory().getClient());
         this.clock = Clock.systemUTC();
@@ -45,10 +45,7 @@ public class SessionService {
 
     public UUID saveSession(SessionRequest sessionRequest) {
         SessionItem sessionItem = new SessionItem();
-        sessionItem.setExpiryDate(
-                clock.instant()
-                        .plus(configurationService.getSessionTtl(), ChronoUnit.SECONDS)
-                        .getEpochSecond());
+        sessionItem.setExpiryDate(configurationService.getSessionExpirationEpoch());
         sessionItem.setState(sessionRequest.getState());
         sessionItem.setClientId(sessionRequest.getClientId());
         sessionItem.setRedirectUri(sessionRequest.getRedirectUri());

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityServiceTest.java
@@ -10,9 +10,6 @@ import uk.gov.di.ipv.cri.common.library.domain.personidentity.SharedClaims;
 import uk.gov.di.ipv.cri.common.library.persistence.DataStore;
 import uk.gov.di.ipv.cri.common.library.persistence.item.personidentity.PersonIdentityItem;
 
-import java.time.Clock;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -26,28 +23,25 @@ class PersonIdentityServiceTest {
     @Mock private PersonIdentityMapper mockPersonIdentityMapper;
     @Mock private ConfigurationService mockConfigurationService;
     @Mock private DataStore<PersonIdentityItem> mockPersonIdentityDataStore;
-    @Mock private Clock mockClock;
     @InjectMocks private PersonIdentityService personIdentityService;
 
     @Test
     void shouldSavePersonIdentity() {
-        long sessionTtl = 30L;
+        final long sessionExpirationEpoch = 1655203777L;
         SharedClaims testSharedClaims = new SharedClaims();
         PersonIdentityItem testPersonIdentityItem = mock(PersonIdentityItem.class);
-        Instant instant = Instant.now();
 
         when(mockPersonIdentityMapper.mapToPersonIdentityItem(testSharedClaims))
                 .thenReturn(testPersonIdentityItem);
-        when(mockConfigurationService.getSessionTtl()).thenReturn(sessionTtl);
-        when(mockClock.instant()).thenReturn(instant);
+        when(mockConfigurationService.getSessionExpirationEpoch())
+                .thenReturn(sessionExpirationEpoch);
 
         personIdentityService.savePersonIdentity(TEST_SESSION_ID, testSharedClaims);
 
         verify(mockPersonIdentityMapper).mapToPersonIdentityItem(testSharedClaims);
         verify(testPersonIdentityItem).setSessionId(TEST_SESSION_ID);
-        verify(mockConfigurationService).getSessionTtl();
-        verify(testPersonIdentityItem)
-                .setExpiryDate(instant.plus(sessionTtl, ChronoUnit.SECONDS).getEpochSecond());
+        verify(mockConfigurationService).getSessionExpirationEpoch();
+        verify(testPersonIdentityItem).setExpiryDate(sessionExpirationEpoch);
         verify(mockPersonIdentityDataStore).create(testPersonIdentityItem);
     }
 

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/SessionServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/SessionServiceTest.java
@@ -57,8 +57,10 @@ class SessionServiceTest {
     }
 
     @Test
-    void shouldCallCreateOnAddressSessionDataStore() {
-        when(mockConfigurationService.getSessionTtl()).thenReturn(1L);
+    void shouldCallCreateOnSessionDataStore() {
+        final long sessionExpirationEpoch = 10L;
+        when(mockConfigurationService.getSessionExpirationEpoch())
+                .thenReturn(sessionExpirationEpoch);
         SessionRequest sessionRequest = mock(SessionRequest.class);
 
         when(sessionRequest.getClientId()).thenReturn("a client id");
@@ -71,7 +73,7 @@ class SessionServiceTest {
         verify(mockDataStore).create(sessionItemArgumentCaptor.capture());
         SessionItem capturedValue = sessionItemArgumentCaptor.getValue();
         assertNotNull(capturedValue.getSessionId());
-        assertThat(capturedValue.getExpiryDate(), equalTo(fixedInstant.getEpochSecond() + 1));
+        assertThat(capturedValue.getExpiryDate(), equalTo(sessionExpirationEpoch));
         assertThat(capturedValue.getClientId(), equalTo("a client id"));
         assertThat(capturedValue.getState(), equalTo("state"));
         assertThat(capturedValue.getSubject(), equalTo("a subject"));
@@ -81,7 +83,7 @@ class SessionServiceTest {
     }
 
     @Test
-    void shouldGetAddressSessionItemByAuthorizationCodeIndexSuccessfully() {
+    void shouldGetSessionItemByAuthorizationCodeIndexSuccessfully() {
         String authCodeValue = UUID.randomUUID().toString();
         SessionItem item = new SessionItem();
         item.setSessionId(UUID.randomUUID());
@@ -99,7 +101,7 @@ class SessionServiceTest {
     }
 
     @Test
-    void shouldGetAddressSessionItemByTokenIndexSuccessfully() {
+    void shouldGetSessionItemByTokenIndexSuccessfully() {
         AccessToken accessToken = new BearerAccessToken();
         String serialisedAccessToken = accessToken.toAuthorizationHeader();
         SessionItem item = new SessionItem();
@@ -127,7 +129,7 @@ class SessionServiceTest {
     }
 
     @Test
-    void saveAddressesThrowsSessionNotFound() {
+    void saveThrowsSessionNotFound() {
         when(mockDataStore.getItem(SESSION_ID)).thenReturn(null);
         assertThrows(
                 SessionNotFoundException.class, () -> sessionService.validateSessionId(SESSION_ID));


### PR DESCRIPTION
### What changed
- Removed some non-common methods from ConfigurationService
- Added a new getSessionExpirationEpoch method to ConfigurationService to avoid the same logic being duplicated in various classes
- Added new methods to retrieve an SSM parameter value and AWS secret by name
- PersonIdentityService and SessionService updated to use the new ConfigurationService method(s)

### Why did it change
The ConfigurationService has been in need of re-working for some time. Non-common functionality should be removed from the this class in future PRs.

### Issue tracking
Related to:
- https://github.com/alphagov/di-ipv-cri-kbv-api/pull/70
