### PR TITLE
KBV-567 Send issuer to TxMA on component_id field

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEvent.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEvent.java
@@ -11,17 +11,29 @@ public class AuditEvent {
     @JsonProperty("event_name")
     private final String event;
 
+    @JsonProperty("component_id")
+    private final String issuer;
+
     @JsonCreator
     public AuditEvent(
             @JsonProperty(value = "timestamp", required = true) long timestamp,
-            @JsonProperty(value = "event_name", required = true) String event) {
+            @JsonProperty(value = "event_name", required = true) String event,
+            @JsonProperty(value = "component_id", required = true) String issuer) {
         this.timestamp = timestamp;
         this.event = event;
+        this.issuer = issuer;
     }
 
     @Override
     public String toString() {
-        return "AuditEvent{" + "timestamp=" + timestamp + ", event=" + event + '}';
+        return "AuditEvent{"
+                + "timestamp="
+                + timestamp
+                + ", event="
+                + event
+                + ", component_id="
+                + issuer
+                + '}';
     }
 
     public long getTimestamp() {

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/AuditService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/AuditService.java
@@ -17,6 +17,7 @@ public class AuditService {
     private final String queueUrl;
     private final ObjectMapper objectMapper;
     private final String eventPrefix;
+    private final String issuer;
 
     private final Clock clock;
 
@@ -38,6 +39,7 @@ public class AuditService {
         this.queueUrl = configurationService.getSqsAuditEventQueueUrl();
         this.objectMapper = objectMapper;
         this.eventPrefix = configurationService.getSqsAuditEventPrefix();
+        this.issuer = configurationService.getVerifiableCredentialIssuer();
         if (StringUtils.isBlank(eventPrefix)) {
             throw new IllegalArgumentException("SQS event prefix is not set");
         }
@@ -63,7 +65,8 @@ public class AuditService {
 
     private String generateMessageBody(String eventType) throws JsonProcessingException {
         AuditEvent auditEvent =
-                new AuditEvent(clock.instant().getEpochSecond(), eventPrefix + "_" + eventType);
+                new AuditEvent(
+                        clock.instant().getEpochSecond(), eventPrefix + "_" + eventType, issuer);
         return objectMapper.writeValueAsString(auditEvent);
     }
 }

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/AuditServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/AuditServiceTest.java
@@ -53,7 +53,10 @@ class AuditServiceTest {
                 ArgumentCaptor.forClass(SendMessageRequest.class);
 
         AuditEvent auditEvent =
-                new AuditEvent(fixedInstant.getEpochSecond(), AuditEventType.START.toString());
+                new AuditEvent(
+                        fixedInstant.getEpochSecond(),
+                        AuditEventType.START.toString(),
+                        "https://cri-issuer");
         String messageAuditEvent = new ObjectMapper().writeValueAsString(auditEvent);
 
         when(mockObjectMapper.writeValueAsString(any(AuditEvent.class)))
@@ -86,7 +89,9 @@ class AuditServiceTest {
 
         AuditEvent auditEvent =
                 new AuditEvent(
-                        fixedInstant.getEpochSecond(), SQS_PREFIX + "_" + AuditEventType.START);
+                        fixedInstant.getEpochSecond(),
+                        SQS_PREFIX + "_" + AuditEventType.START,
+                        "https://cri-issuer");
         String messageAuditEvent = new ObjectMapper().writeValueAsString(auditEvent);
         when(mockObjectMapper.writeValueAsString(any(AuditEvent.class)))
                 .thenReturn(messageAuditEvent);

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/AuditServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/AuditServiceTest.java
@@ -71,6 +71,8 @@ class AuditServiceTest {
         verify(mockSqs).sendMessage(capturedValue);
 
         assertEquals(messageAuditEvent, capturedValue.messageBody());
+        assertThat(capturedValue.messageBody(), containsString("component_id"));
+        assertThat(capturedValue.messageBody(), containsString("https://cri-issuer"));
         assertEquals(SQS_QUEUE_URL, capturedValue.queueUrl());
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

TxMA have asked for a component id to be sent to TxMA.

See Jira story, which says:
> "component_id" requires adding to each event message - this is either the URI or short name (e.g. SPOT)

Send the CRI issuer uri as this value.

This will be a non-breaking change that CRIs will pick up when they use the merged Pr code.


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-567](https://govukverify.atlassian.net/browse/KBV-567)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks