### PR TITLE
BAU - ConfigurationService - remove redundant / CRI-specific methods

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/DataStore.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/DataStore.java
@@ -15,7 +15,6 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 
-import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -32,14 +31,6 @@ public class DataStore<T> {
         this.tableName = tableName;
         this.typeParameterClass = typeParameterClass;
         this.dynamoDbEnhancedClient = dynamoDbEnhancedClient;
-    }
-
-    public static DynamoDbEnhancedClient getClient(URI endpointOverride) {
-        DynamoDbClientBuilder clientBuilder =
-                getDynamoDbClientBuilder(
-                        DynamoDbClient.builder().endpointOverride(endpointOverride));
-
-        return DynamoDbEnhancedClient.builder().dynamoDbClient(clientBuilder.build()).build();
     }
 
     public static DynamoDbEnhancedClient getClient() {

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/ListUtil.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/ListUtil.java
@@ -1,10 +1,11 @@
 package uk.gov.di.ipv.cri.common.library.util;
 
 import java.util.List;
+import java.util.Objects;
 
 public class ListUtil {
     public <T> T getOneItemOrThrowError(List<T> list) throws IllegalArgumentException {
-        if (list.size() == 0) {
+        if (Objects.isNull(list) || list.isEmpty()) {
             throw new IllegalArgumentException("No items found");
         } else if (list.size() > 1) {
             throw new IllegalArgumentException("More than one item found");

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java
@@ -75,17 +75,4 @@ class ConfigurationServiceTest {
                 .thenReturn(String.valueOf(sessionTtl));
         assertEquals(sessionTtl, configurationService.getSessionTtl());
     }
-
-    @Test
-    void shouldGetOrdnanceSurveyAPIKey() {
-        when(mockSecretsProvider.get(
-                        String.format(
-                                PARAM_NAME_FORMAT,
-                                TEST_STACK_NAME,
-                                ConfigurationService.SSMParameterName.ORDNANCE_SURVEY_API_KEY
-                                        .parameterName)))
-                .thenReturn("1234567890");
-
-        assertEquals("1234567890", configurationService.getOsApiKey());
-    }
 }


### PR DESCRIPTION
### What changed
- `ConfigurationService` - Removed address CRI specific methods & redundant `getDynamoDbEndpointOverride` methods 
- `ListUtil` - corrected a sonar lint code smell
- `DataStore` - removed redundant static method: `getClient(URI endpointOverride)`

### Why did it change
It's part of recent work to remove CRI-specifc code from common-lib
