### PR TITLE
[BAU] - Add a "toString()" override for ErrorResponse

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/common/library/error/ErrorResponse.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/error/ErrorResponse.java
@@ -48,4 +48,9 @@ public enum ErrorResponse {
     public String getMessage() {
         return message;
     }
+
+    @Override
+    public String toString() {
+        return getCode() + ": " + getMessage();
+    }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/error/ErrorResponse.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/error/ErrorResponse.java
@@ -49,8 +49,7 @@ public enum ErrorResponse {
         return message;
     }
 
-    @Override
-    public String toString() {
+    public String getErrorSummary() {
         return getCode() + ": " + getMessage();
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

A toString() override was added to the ErrorResponse to enable both code and message to be rendered correctly within the Nimbus OAuth2Error

### Why did it change

In updating to return response errors in the same way as core, the ErrorResponse was not being correctly interpreted as a string
