### PR TITLE
KBV-567 - Add metadata to audit events

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEvent.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEvent.java
@@ -1,9 +1,12 @@
 package uk.gov.di.ipv.cri.common.library.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
 
-public class AuditEvent {
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AuditEvent<T> {
 
     @JsonProperty("timestamp")
     private final long timestamp;
@@ -13,6 +16,9 @@ public class AuditEvent {
 
     @JsonProperty("component_id")
     private final String issuer;
+
+    private PersonIdentityDetailed restricted;
+    private T extensions;
 
     @JsonCreator
     public AuditEvent(
@@ -42,5 +48,21 @@ public class AuditEvent {
 
     public String getEvent() {
         return event;
+    }
+
+    public PersonIdentityDetailed getRestricted() {
+        return restricted;
+    }
+
+    public void setRestricted(PersonIdentityDetailed restricted) {
+        this.restricted = restricted;
+    }
+
+    public T getExtensions() {
+        return extensions;
+    }
+
+    public void setExtensions(T extensions) {
+        this.extensions = extensions;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/Address.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/Address.java
@@ -8,7 +8,6 @@ import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.time.chrono.ChronoLocalDate;
 import java.util.Objects;
-import java.util.Optional;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Address {
@@ -32,8 +31,8 @@ public class Address {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate validUntil;
 
-    public Optional<Long> getUprn() {
-        return Optional.ofNullable(this.uprn);
+    public Long getUprn() {
+        return this.uprn;
     }
 
     public void setUprn(Long uprn) {

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/Address.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/Address.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.cri.common.library.domain.personidentity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.time.LocalDate;
@@ -151,6 +152,7 @@ public class Address {
         this.validUntil = validUntil;
     }
 
+    @JsonIgnore
     public AddressType getAddressType() {
         if (Objects.nonNull(this.getValidUntil()) && isPastDate(this.getValidUntil())) {
             return AddressType.PREVIOUS;

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/CanonicalAddress.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/CanonicalAddress.java
@@ -7,7 +7,6 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import java.time.LocalDate;
 import java.util.Date;
 import java.util.Objects;
-import java.util.Optional;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @DynamoDbBean
@@ -45,8 +44,8 @@ public class CanonicalAddress {
         // Default constructor
     }
 
-    public Optional<Long> getUprn() {
-        return Optional.ofNullable(this.uprn);
+    public Long getUprn() {
+        return this.uprn;
     }
 
     public void setUprn(Long uprn) {

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/AuditService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/AuditService.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.cri.common.library.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.utils.StringUtils;
@@ -27,7 +28,7 @@ public class AuditService {
         this(
                 SqsClient.builder().build(),
                 new ConfigurationService(),
-                new ObjectMapper(),
+                new ObjectMapper().registerModule(new JavaTimeModule()),
                 Clock.systemUTC());
     }
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapper.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapper.java
@@ -118,7 +118,7 @@ class PersonIdentityMapper {
                             mappedAddress.setPostalCode(address.getPostalCode());
                             mappedAddress.setStreetName(address.getStreetName());
                             mappedAddress.setSubBuildingName(address.getSubBuildingName());
-                            mappedAddress.setUprn(address.getUprn().orElse(null));
+                            mappedAddress.setUprn(address.getUprn());
                             mappedAddress.setValidFrom(address.getValidFrom());
                             mappedAddress.setValidUntil(address.getValidUntil());
                             return mappedAddress;
@@ -270,7 +270,7 @@ class PersonIdentityMapper {
                 .map(
                         a -> {
                             CanonicalAddress canonicalAddress = new CanonicalAddress();
-                            canonicalAddress.setUprn(a.getUprn().orElse(null));
+                            canonicalAddress.setUprn(a.getUprn());
                             canonicalAddress.setOrganisationName(a.getOrganisationName());
                             canonicalAddress.setDepartmentName(a.getDepartmentName());
                             canonicalAddress.setSubBuildingName(a.getSubBuildingName());

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityService.java
@@ -55,6 +55,11 @@ public class PersonIdentityService {
         return personIdentityMapper.mapToPersonIdentityDetailed(personIdentityItem);
     }
 
+    public PersonIdentity convertToPersonIdentitySummary(
+            PersonIdentityDetailed personIdentityDetailed) {
+        return personIdentityMapper.mapToPersonIdentity(personIdentityDetailed);
+    }
+
     private PersonIdentityItem getById(UUID sessionId) {
         return this.personIdentityDataStore.getItem(String.valueOf(sessionId));
     }

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapperTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapperTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.BirthDate;
@@ -277,5 +278,49 @@ class PersonIdentityMapperTest {
         assertEquals(address.getStreetName(), mappedAddress.getStreetName());
         assertEquals(address.getSubBuildingName(), mappedAddress.getSubBuildingName());
         assertEquals(address.getUprn(), mappedAddress.getUprn());
+    }
+
+    @Test
+    void shouldMapPersonIdentityDetailedToPersonIdentity() {
+        NamePart firstNamePart = new NamePart();
+        firstNamePart.setType("GivenName");
+        firstNamePart.setValue("Jon");
+        NamePart middleNamePart = new NamePart();
+        middleNamePart.setType("GivenName");
+        middleNamePart.setValue("Alexander");
+        NamePart surnamePart = new NamePart();
+        surnamePart.setType("FamilyName");
+        surnamePart.setValue("Smith");
+        Name name = new Name();
+        name.setNameParts(List.of(firstNamePart, middleNamePart, surnamePart));
+
+        BirthDate birthDate = new BirthDate();
+        birthDate.setValue(LocalDate.of(1980, 10, 20));
+
+        Address address = new Address();
+        address.setBuildingNumber("buildingNum");
+        address.setBuildingName("buildingName");
+        address.setStreetName("street");
+        address.setAddressLocality("locality");
+        address.setPostalCode("postcode");
+        address.setValidFrom(TODAY);
+
+        PersonIdentityDetailed testPersonIdentity = new PersonIdentityDetailed(List.of(name), List.of(birthDate), List.of(address));
+
+        PersonIdentity mappedPersonIdentity =
+                this.personIdentityMapper.mapToPersonIdentity(testPersonIdentity);
+
+        assertEquals(firstNamePart.getValue(), mappedPersonIdentity.getFirstName());
+        assertEquals(middleNamePart.getValue(), mappedPersonIdentity.getMiddleNames());
+        assertEquals(surnamePart.getValue(), mappedPersonIdentity.getSurname());
+        assertEquals(birthDate.getValue(), mappedPersonIdentity.getDateOfBirth());
+        Address mappedAddress = mappedPersonIdentity.getAddresses().get(0);
+        assertEquals(address.getBuildingName(), mappedAddress.getBuildingName());
+        assertEquals(address.getBuildingNumber(), mappedAddress.getBuildingNumber());
+        assertEquals(address.getStreetName(), mappedAddress.getStreetName());
+        assertEquals(address.getAddressLocality(), mappedAddress.getAddressLocality());
+        assertEquals(address.getPostalCode(), mappedAddress.getPostalCode());
+        assertEquals(address.getValidFrom(), mappedAddress.getValidFrom());
+        assertEquals(AddressType.CURRENT, mappedAddress.getAddressType());
     }
 }

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapperTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapperTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.annotations.SdkTestInternalApi;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.AddressType;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.BirthDate;
@@ -305,7 +304,8 @@ class PersonIdentityMapperTest {
         address.setPostalCode("postcode");
         address.setValidFrom(TODAY);
 
-        PersonIdentityDetailed testPersonIdentity = new PersonIdentityDetailed(List.of(name), List.of(birthDate), List.of(address));
+        PersonIdentityDetailed testPersonIdentity =
+                new PersonIdentityDetailed(List.of(name), List.of(birthDate), List.of(address));
 
         PersonIdentity mappedPersonIdentity =
                 this.personIdentityMapper.mapToPersonIdentity(testPersonIdentity);


### PR DESCRIPTION
### What changed
- `AuditEvent` has 2 new fields: `restricted` for PII and `extensions` for event-specific data
- `AuditService` has new methods to allow PII and extensions data to be recorded when an audit event is sent
- `PersonIdentityMapper` has a new method to map from `PersonIdentityDetailed` to the summarised `PersonIdentity`
- 'Address' & `CanonicalAddress` removed Optional<Long> type as this doesn't get omitted when serialised when it is empty. Instead we get  "uprn": { "empty": true, "present": false }

### Why did it change
To enable audit event metadata to be sent

### Issue tracking
- [KBV-567](https://govukverify.atlassian.net/browse/KBV-567)
