### PR TITLE
Add user object to AuditEvent

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEvent.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEvent.java
@@ -18,6 +18,7 @@ public class AuditEvent<T> {
     private final String issuer;
 
     private PersonIdentityDetailed restricted;
+    private AuditEventUser user;
     private T extensions;
 
     @JsonCreator
@@ -64,5 +65,13 @@ public class AuditEvent<T> {
 
     public void setExtensions(T extensions) {
         this.extensions = extensions;
+    }
+
+    public AuditEventUser getUser() {
+        return user;
+    }
+
+    public void setUser(AuditEventUser user) {
+        this.user = user;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEventContext.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEventContext.java
@@ -1,0 +1,37 @@
+package uk.gov.di.ipv.cri.common.library.domain;
+
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
+import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
+
+import java.util.Map;
+
+public class AuditEventContext {
+    private final PersonIdentityDetailed personIdentity;
+    private final Map<String, String> requestHeaders;
+    private final SessionItem sessionItem;
+
+    public AuditEventContext(
+            PersonIdentityDetailed personIdentity,
+            Map<String, String> requestHeaders,
+            SessionItem sessionItem) {
+        this.personIdentity = personIdentity;
+        this.requestHeaders = requestHeaders;
+        this.sessionItem = sessionItem;
+    }
+
+    public AuditEventContext(Map<String, String> requestHeaders, SessionItem sessionItem) {
+        this(null, requestHeaders, sessionItem);
+    }
+
+    public PersonIdentityDetailed getPersonIdentity() {
+        return personIdentity;
+    }
+
+    public Map<String, String> getRequestHeaders() {
+        return requestHeaders;
+    }
+
+    public SessionItem getSessionItem() {
+        return sessionItem;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEventUser.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEventUser.java
@@ -1,0 +1,40 @@
+package uk.gov.di.ipv.cri.common.library.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AuditEventUser {
+    @JsonProperty("user_id")
+    private String userId;
+
+    @JsonProperty("ip_address")
+    private String ipAddress;
+
+    @JsonProperty("session_id")
+    private String sessionId;
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/PersonIdentityDetailed.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/PersonIdentityDetailed.java
@@ -1,9 +1,11 @@
 package uk.gov.di.ipv.cri.common.library.domain.personidentity;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class PersonIdentityDetailed {
     @JsonProperty("name")
     private final List<Name> names;

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactory.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactory.java
@@ -1,0 +1,69 @@
+package uk.gov.di.ipv.cri.common.library.service;
+
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+import uk.gov.di.ipv.cri.common.library.domain.AuditEvent;
+import uk.gov.di.ipv.cri.common.library.domain.AuditEventContext;
+import uk.gov.di.ipv.cri.common.library.domain.AuditEventUser;
+import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
+
+import java.time.Clock;
+import java.util.Map;
+import java.util.Objects;
+
+public class AuditEventFactory {
+    private static final String CLIENT_IP_HEADER_KEY = "X-Forwarded-For";
+
+    private final String eventPrefix;
+    private final String issuer;
+    private final Clock clock;
+
+    public AuditEventFactory(ConfigurationService configurationService, Clock clock) {
+        this.eventPrefix = configurationService.getSqsAuditEventPrefix();
+        if (StringUtils.isBlank(this.eventPrefix)) {
+            throw new IllegalStateException(
+                    "Audit event prefix not retrieved from configuration service");
+        }
+        this.issuer = configurationService.getVerifiableCredentialIssuer();
+        if (StringUtils.isBlank(this.issuer)) {
+            throw new IllegalStateException("Issuer not retrieved from configuration service");
+        }
+        this.clock = Objects.requireNonNull(clock, "clock must not be null");
+    }
+
+    <T> AuditEvent<T> create(String eventType, AuditEventContext auditEventContext, T extensions) {
+        AuditEvent<T> auditEvent =
+                new AuditEvent<>(
+                        clock.instant().getEpochSecond(), eventPrefix + "_" + eventType, issuer);
+        if (Objects.nonNull(auditEventContext)) {
+            if (Objects.nonNull(auditEventContext.getPersonIdentity())) {
+                auditEvent.setRestricted(auditEventContext.getPersonIdentity());
+            }
+            auditEvent.setUser(
+                    createAuditEventUser(
+                            auditEventContext.getRequestHeaders(),
+                            auditEventContext.getSessionItem()));
+        }
+        if (Objects.nonNull(extensions)) {
+            auditEvent.setExtensions(extensions);
+        }
+        return auditEvent;
+    }
+
+    private AuditEventUser createAuditEventUser(
+            Map<String, String> requestHeaders, SessionItem sessionItem) {
+        AuditEventUser userInfo = null;
+
+        if (Objects.nonNull(sessionItem)) {
+            userInfo = new AuditEventUser();
+            userInfo.setSessionId(String.valueOf(sessionItem.getSessionId()));
+            userInfo.setUserId(sessionItem.getSubject());
+        }
+
+        if (requestHeaders.containsKey(CLIENT_IP_HEADER_KEY)) {
+            (Objects.nonNull(userInfo) ? userInfo : (userInfo = new AuditEventUser()))
+                    .setIpAddress(requestHeaders.get(CLIENT_IP_HEADER_KEY));
+        }
+
+        return userInfo;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactory.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactory.java
@@ -60,8 +60,10 @@ public class AuditEventFactory {
         }
 
         if (requestHeaders.containsKey(CLIENT_IP_HEADER_KEY)) {
-            (Objects.nonNull(userInfo) ? userInfo : (userInfo = new AuditEventUser()))
-                    .setIpAddress(requestHeaders.get(CLIENT_IP_HEADER_KEY));
+            if (Objects.isNull(userInfo)) {
+                userInfo = new AuditEventUser();
+            }
+            userInfo.setIpAddress(requestHeaders.get(CLIENT_IP_HEADER_KEY));
         }
 
         return userInfo;

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactoryTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactoryTest.java
@@ -1,0 +1,132 @@
+package uk.gov.di.ipv.cri.common.library.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.domain.AuditEvent;
+import uk.gov.di.ipv.cri.common.library.domain.AuditEventContext;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
+import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuditEventFactoryTest {
+
+    private static final String TEST_AUDIT_EVENT_PREFIX = "AUDIT_EVENT_PREFIX";
+    private static final String TEST_VC_ISSUER = "VC_ISSUER";
+
+    @Mock private Clock mockClock;
+    @Mock private ConfigurationService mockConfigurationService;
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldThrowExceptionWhenAuditEventPrefixNullOrEmpty(String auditEventPrefix) {
+        when(mockConfigurationService.getSqsAuditEventPrefix()).thenReturn(auditEventPrefix);
+        assertThrows(
+                IllegalStateException.class,
+                () -> new AuditEventFactory(mockConfigurationService, mockClock),
+                "Audit event prefix not retrieved from configuration service");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldThrowExceptionWhenVcIssuerNullOrEmpty(String vcIssuer) {
+        when(mockConfigurationService.getSqsAuditEventPrefix()).thenReturn(TEST_AUDIT_EVENT_PREFIX);
+        when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(vcIssuer);
+        assertThrows(
+                IllegalStateException.class,
+                () -> new AuditEventFactory(mockConfigurationService, mockClock),
+                "Issuer not retrieved from configuration service");
+    }
+
+    @Test
+    void shouldThrowExceptionWhenClockIsNull() {
+        when(mockConfigurationService.getSqsAuditEventPrefix()).thenReturn(TEST_AUDIT_EVENT_PREFIX);
+        when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(TEST_VC_ISSUER);
+        assertThrows(
+                NullPointerException.class,
+                () -> new AuditEventFactory(mockConfigurationService, null),
+                "clock must not be null");
+    }
+
+    @Test
+    void shouldCreateAuditEventWithContextAndExtensions() {
+        long timestamp = 1656947224L;
+        String userId = String.valueOf(UUID.randomUUID());
+        UUID sessionId = UUID.randomUUID();
+        String clientIpAddress = "81.145.61.43";
+        when(mockConfigurationService.getSqsAuditEventPrefix()).thenReturn(TEST_AUDIT_EVENT_PREFIX);
+        when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(TEST_VC_ISSUER);
+        Instant mockInstant = mock(Instant.class);
+        when(mockInstant.getEpochSecond()).thenReturn(timestamp);
+        when(mockClock.instant()).thenReturn(mockInstant);
+        PersonIdentityDetailed personIdentity = mock(PersonIdentityDetailed.class);
+        Map<String, String> requestHeaders = Map.of("X-Forwarded-For", clientIpAddress);
+        SessionItem sessionItem = mock(SessionItem.class);
+        when(sessionItem.getSubject()).thenReturn(userId);
+        when(sessionItem.getSessionId()).thenReturn(sessionId);
+        AuditEventContext auditEventContext =
+                new AuditEventContext(personIdentity, requestHeaders, sessionItem);
+        AuditEventFactory auditEventFactory =
+                new AuditEventFactory(mockConfigurationService, mockClock);
+        Map<String, String> auditEventExtensions = Map.of("test", "extension-data");
+
+        AuditEvent<Object> auditEvent =
+                auditEventFactory.create("EVENT_TYPE", auditEventContext, auditEventExtensions);
+
+        assertEquals(TEST_AUDIT_EVENT_PREFIX + "_EVENT_TYPE", auditEvent.getEvent());
+        assertEquals(personIdentity, auditEvent.getRestricted());
+        assertEquals(timestamp, auditEvent.getTimestamp());
+        assertEquals(userId, auditEvent.getUser().getUserId());
+        assertEquals(clientIpAddress, auditEvent.getUser().getIpAddress());
+        assertEquals(String.valueOf(sessionId), auditEvent.getUser().getSessionId());
+        assertEquals(auditEventExtensions, auditEvent.getExtensions());
+
+        verify(mockClock).instant();
+        verify(mockInstant).getEpochSecond();
+        verify(mockConfigurationService).getSqsAuditEventPrefix();
+        verify(mockConfigurationService).getVerifiableCredentialIssuer();
+    }
+
+    @Test
+    void shouldCreateAuditEventWithContext() {
+        long timestamp = 1656947224L;
+        String clientIpAddress = "81.145.61.43";
+        when(mockConfigurationService.getSqsAuditEventPrefix()).thenReturn(TEST_AUDIT_EVENT_PREFIX);
+        when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(TEST_VC_ISSUER);
+        Instant mockInstant = mock(Instant.class);
+        when(mockInstant.getEpochSecond()).thenReturn(timestamp);
+        when(mockClock.instant()).thenReturn(mockInstant);
+        PersonIdentityDetailed personIdentity = mock(PersonIdentityDetailed.class);
+        Map<String, String> requestHeaders = Map.of("X-Forwarded-For", clientIpAddress);
+        AuditEventContext auditEventContext =
+                new AuditEventContext(personIdentity, requestHeaders, null);
+        AuditEventFactory auditEventFactory =
+                new AuditEventFactory(mockConfigurationService, mockClock);
+
+        AuditEvent<Object> auditEvent =
+                auditEventFactory.create("EVENT_TYPE", auditEventContext, null);
+
+        assertEquals(TEST_AUDIT_EVENT_PREFIX + "_EVENT_TYPE", auditEvent.getEvent());
+        assertEquals(personIdentity, auditEvent.getRestricted());
+        assertEquals(timestamp, auditEvent.getTimestamp());
+        assertEquals(clientIpAddress, auditEvent.getUser().getIpAddress());
+        assertNull(auditEvent.getUser().getUserId());
+        assertNull(auditEvent.getUser().getSessionId());
+        assertNull(auditEvent.getExtensions());
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/AuditServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/AuditServiceTest.java
@@ -2,9 +2,11 @@ package uk.gov.di.ipv.cri.common.library.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -12,22 +14,14 @@ import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEvent;
+import uk.gov.di.ipv.cri.common.library.domain.AuditEventContext;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEventType;
-import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
-import uk.gov.di.ipv.cri.common.library.domain.personidentity.BirthDate;
-import uk.gov.di.ipv.cri.common.library.domain.personidentity.Name;
-import uk.gov.di.ipv.cri.common.library.domain.personidentity.NamePart;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
 import uk.gov.di.ipv.cri.common.library.exception.SqsException;
+import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
 
-import java.time.Clock;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -37,37 +31,32 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AuditServiceTest {
-    private final String SQS_QUEUE_URL = "https://example-queue-url";
-    private final String SQS_PREFIX = "TEST";
+    private static final String SQS_QUEUE_URL = "https://example-queue-url";
 
     @Mock private SqsClient mockSqs;
     @Mock private ConfigurationService mockConfigurationService;
     @Mock private ObjectMapper mockObjectMapper;
-    @Mock private Clock mockClock;
+    @Mock private AuditEventFactory mockAuditEventFactory;
     private AuditService auditService;
 
-    @Test
-    void shouldSendMessageToSqsQueue() throws JsonProcessingException, SqsException {
+    @BeforeEach
+    void setup() {
         when(mockConfigurationService.getSqsAuditEventQueueUrl()).thenReturn(SQS_QUEUE_URL);
-        when(mockConfigurationService.getSqsAuditEventPrefix()).thenReturn(SQS_PREFIX);
-        Instant fixedInstant = Instant.now();
-        when(mockClock.instant()).thenReturn(fixedInstant);
+        this.auditService =
+                new AuditService(
+                        mockSqs, mockConfigurationService, mockObjectMapper, mockAuditEventFactory);
+    }
 
-        auditService =
-                new AuditService(mockSqs, mockConfigurationService, mockObjectMapper, mockClock);
-
+    @Test
+    void shouldSendMessageToSqsQueue(@Mock AuditEvent<Object> auditEvent)
+            throws JsonProcessingException, SqsException {
         ArgumentCaptor<SendMessageRequest> sqsSendMessageRequestCaptor =
                 ArgumentCaptor.forClass(SendMessageRequest.class);
+        String serialisedAuditEvent = "serialised auditEvent";
 
-        AuditEvent auditEvent =
-                new AuditEvent(
-                        fixedInstant.getEpochSecond(),
-                        AuditEventType.START.toString(),
-                        "https://cri-issuer");
-        String messageAuditEvent = new ObjectMapper().writeValueAsString(auditEvent);
-
-        when(mockObjectMapper.writeValueAsString(any(AuditEvent.class)))
-                .thenReturn(messageAuditEvent);
+        when(mockAuditEventFactory.create(AuditEventType.START.toString(), null, null))
+                .thenReturn(auditEvent);
+        when(mockObjectMapper.writeValueAsString(auditEvent)).thenReturn(serialisedAuditEvent);
 
         SendMessageResponse mockSendMessageResponse = mock(SendMessageResponse.class);
         when(mockSqs.sendMessage(sqsSendMessageRequestCaptor.capture()))
@@ -76,132 +65,71 @@ class AuditServiceTest {
         auditService.sendAuditEvent(AuditEventType.START);
         SendMessageRequest capturedValue = sqsSendMessageRequestCaptor.getValue();
         verify(mockSqs).sendMessage(capturedValue);
-
-        assertEquals(messageAuditEvent, capturedValue.messageBody());
-        assertThat(capturedValue.messageBody(), containsString("component_id"));
-        assertThat(capturedValue.messageBody(), containsString("https://cri-issuer"));
+        verify(mockAuditEventFactory).create("START", null, null);
+        verify(mockObjectMapper).writeValueAsString(auditEvent);
+        assertEquals(serialisedAuditEvent, capturedValue.messageBody());
         assertEquals(SQS_QUEUE_URL, capturedValue.queueUrl());
     }
 
     @Test
-    void shouldCorrectlyAddPrefix() throws SqsException, JsonProcessingException {
-        when(mockConfigurationService.getSqsAuditEventQueueUrl()).thenReturn(SQS_QUEUE_URL);
-        when(mockConfigurationService.getSqsAuditEventPrefix()).thenReturn(SQS_PREFIX);
-        Instant fixedInstant = Instant.now();
-        when(mockClock.instant()).thenReturn(fixedInstant);
+    void shouldSendAuditEventWithContext(@Mock AuditEvent<Object> auditEvent)
+            throws SqsException, JsonProcessingException {
+        AuditEventContext auditEventContext =
+                new AuditEventContext(
+                        mock(PersonIdentityDetailed.class),
+                        Map.of("test-header-name", "test-header-value"),
+                        new SessionItem());
+        when(mockAuditEventFactory.create(AuditEventType.START.toString(), auditEventContext, null))
+                .thenReturn(auditEvent);
+        when(mockObjectMapper.writeValueAsString(auditEvent)).thenReturn("serialised audit event");
 
-        auditService =
-                new AuditService(mockSqs, mockConfigurationService, mockObjectMapper, mockClock);
+        auditService.sendAuditEvent(AuditEventType.START, auditEventContext);
 
-        ArgumentCaptor<SendMessageRequest> sqsSendMessageRequestCaptor =
-                ArgumentCaptor.forClass(SendMessageRequest.class);
-
-        AuditEvent auditEvent =
-                new AuditEvent(
-                        fixedInstant.getEpochSecond(),
-                        SQS_PREFIX + "_" + AuditEventType.START,
-                        "https://cri-issuer");
-
-        String messageAuditEvent = new ObjectMapper().writeValueAsString(auditEvent);
-        when(mockObjectMapper.writeValueAsString(any(AuditEvent.class)))
-                .thenReturn(messageAuditEvent);
-
-        SendMessageResponse mockSendMessageResponse = mock(SendMessageResponse.class);
-        when(mockSqs.sendMessage(sqsSendMessageRequestCaptor.capture()))
-                .thenReturn(mockSendMessageResponse);
-
-        auditService.sendAuditEvent(AuditEventType.START);
-        SendMessageRequest capturedValue = sqsSendMessageRequestCaptor.getValue();
-        verify(mockSqs).sendMessage(capturedValue);
-
-        assertThat(
-                capturedValue.messageBody(),
-                containsString(SQS_PREFIX + "_" + AuditEventType.START));
-        assertEquals(SQS_QUEUE_URL, capturedValue.queueUrl());
+        verify(mockAuditEventFactory)
+                .create(AuditEventType.START.toString(), auditEventContext, null);
+        verify(mockSqs).sendMessage(any(SendMessageRequest.class));
     }
 
     @Test
-    void ConstructorShouldThrowErrorWhenNoPrefix() throws SqsException {
-        when(mockConfigurationService.getSqsAuditEventQueueUrl()).thenReturn(SQS_QUEUE_URL);
-        when(mockConfigurationService.getSqsAuditEventPrefix()).thenReturn("");
+    void shouldSendAuditEventWithExtensionsData(@Mock AuditEvent<Map<String, Object>> auditEvent)
+            throws SqsException, JsonProcessingException {
+        Map<String, Object> extensionsDataEntries = Map.of("test", "value");
+        when(mockAuditEventFactory.create(
+                        AuditEventType.START.toString(), null, extensionsDataEntries))
+                .thenReturn(auditEvent);
+        when(mockObjectMapper.writeValueAsString(auditEvent)).thenReturn("serialised audit event");
+        auditService.sendAuditEvent(AuditEventType.START, extensionsDataEntries);
+        verify(mockAuditEventFactory)
+                .create(AuditEventType.START.toString(), null, extensionsDataEntries);
+        verify(mockObjectMapper).writeValueAsString(auditEvent);
+        verify(mockSqs).sendMessage(any(SendMessageRequest.class));
+    }
+
+    @Test
+    void shouldThrowSqsExceptionWhenSerialisationFails(@Mock AuditEvent<Object> auditEvent)
+            throws JsonProcessingException {
+        String audiEventType = "CUSTOM_AUDIT_EVENT_TYPE";
+        when(mockAuditEventFactory.create(audiEventType, null, null)).thenReturn(auditEvent);
+        when(mockObjectMapper.writeValueAsString(auditEvent))
+                .thenThrow(mock(JsonProcessingException.class));
 
         assertThrows(
-                IllegalArgumentException.class,
+                SqsException.class, () -> auditService.sendAuditEvent("CUSTOM_AUDIT_EVENT_TYPE"));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void ConstructorShouldThrowErrorWhenNoQueueUrl(String input) {
+        when(mockConfigurationService.getSqsAuditEventQueueUrl()).thenReturn(input);
+
+        assertThrows(
+                IllegalStateException.class,
                 () ->
                         new AuditService(
-                                mockSqs, mockConfigurationService, mockObjectMapper, mockClock));
-    }
-
-    @Test
-    void shouldAddRestrictedData() throws SqsException {
-        when(mockConfigurationService.getSqsAuditEventQueueUrl()).thenReturn(SQS_QUEUE_URL);
-        when(mockConfigurationService.getSqsAuditEventPrefix()).thenReturn(SQS_PREFIX);
-        when(mockClock.instant()).thenReturn(Instant.now());
-
-        auditService =
-                new AuditService(
-                        mockSqs,
-                        mockConfigurationService,
-                        new ObjectMapper().registerModule(new JavaTimeModule()),
-                        mockClock);
-
-        PersonIdentityDetailed personIdentity = createPersonIdentity();
-
-        ArgumentCaptor<SendMessageRequest> sqsSendMessageRequestCaptor =
-                ArgumentCaptor.forClass(SendMessageRequest.class);
-        SendMessageResponse mockSendMessageResponse = mock(SendMessageResponse.class);
-        when(mockSqs.sendMessage(sqsSendMessageRequestCaptor.capture()))
-                .thenReturn(mockSendMessageResponse);
-
-        auditService.sendAuditEvent(AuditEventType.START, personIdentity);
-        SendMessageRequest capturedValue = sqsSendMessageRequestCaptor.getValue();
-        verify(mockSqs).sendMessage(capturedValue);
-
-        assertThat(capturedValue.messageBody(), containsString("Joe"));
-        assertEquals(SQS_QUEUE_URL, capturedValue.queueUrl());
-    }
-
-    @Test
-    void shouldAddExtensionsMap() throws SqsException {
-        when(mockConfigurationService.getSqsAuditEventQueueUrl()).thenReturn(SQS_QUEUE_URL);
-        when(mockConfigurationService.getSqsAuditEventPrefix()).thenReturn(SQS_PREFIX);
-        when(mockClock.instant()).thenReturn(Instant.now());
-
-        auditService =
-                new AuditService(mockSqs, mockConfigurationService, new ObjectMapper(), mockClock);
-
-        ArgumentCaptor<SendMessageRequest> sqsSendMessageRequestCaptor =
-                ArgumentCaptor.forClass(SendMessageRequest.class);
-        SendMessageResponse mockSendMessageResponse = mock(SendMessageResponse.class);
-        when(mockSqs.sendMessage(sqsSendMessageRequestCaptor.capture()))
-                .thenReturn(mockSendMessageResponse);
-
-        auditService.sendAuditEvent(AuditEventType.START, Map.of("foo", "bar"));
-        SendMessageRequest capturedValue = sqsSendMessageRequestCaptor.getValue();
-        verify(mockSqs).sendMessage(capturedValue);
-
-        assertThat(capturedValue.messageBody(), containsString("foo"));
-        assertEquals(SQS_QUEUE_URL, capturedValue.queueUrl());
-    }
-
-    private PersonIdentityDetailed createPersonIdentity() {
-        Address address = new Address();
-        address.setBuildingNumber("114");
-        address.setStreetName("Wellington Street");
-        address.setPostalCode("LS1 1BA");
-
-        Name name = new Name();
-        NamePart firstNamePart = new NamePart();
-        firstNamePart.setType("GivenName");
-        firstNamePart.setValue("Joe");
-        NamePart surnamePart = new NamePart();
-        surnamePart.setType("FamilyName");
-        surnamePart.setValue("Bloggs");
-        name.setNameParts(List.of(firstNamePart, surnamePart));
-
-        BirthDate birthDate = new BirthDate();
-        birthDate.setValue(LocalDate.of(1980, 1, 1));
-
-        return new PersonIdentityDetailed(List.of(name), List.of(birthDate), List.of(address));
+                                mockSqs,
+                                mockConfigurationService,
+                                mockObjectMapper,
+                                mockAuditEventFactory),
+                "Null or empty queue url provided by configuration service");
     }
 }


### PR DESCRIPTION
### What changed
- Added `user` object to AuditEvent
- Overhauled AuditService implementation
- Refactored the DataStore based on amends made by the core team 

### Why did it change
To enable user-specific audit data to be sent to TxMA

### Issue tracking
- [KBV-622](https://govukverify.atlassian.net/browse/KBV-622)
