### PR TITLE
BAU - optimise dynamo db client startup time

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/DynamoDbEnhancedClientFactory.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/DynamoDbEnhancedClientFactory.java
@@ -1,5 +1,6 @@
 package uk.gov.di.ipv.cri.common.library.persistence;
 
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
@@ -12,6 +13,7 @@ public class DynamoDbEnhancedClientFactory {
     public DynamoDbEnhancedClientFactory() {
         DynamoDbClient dynamoDbClient =
                 DynamoDbClient.builder()
+                        .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
                         .httpClient(UrlConnectionHttpClient.create())
                         .region(Region.EU_WEST_2)
                         .build();


### PR DESCRIPTION
### What changed
Explicitly specified the credentials provider for the dynamo db client

### Why did it change
To improve dynamo db client startup time
As per:
https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/lambda-optimize-starttime.html
