### PR TITLE
KBV-771: Change Address getAddressType() to return PREVIOUS for null …

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/Address.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/Address.java
@@ -153,17 +153,13 @@ public class Address {
 
     @JsonIgnore
     public AddressType getAddressType() {
-        if (Objects.nonNull(this.getValidUntil()) && isPastDate(this.getValidUntil())) {
-            return AddressType.PREVIOUS;
-        }
-
         if (Objects.isNull(this.getValidUntil())
                 && (Objects.nonNull(this.getValidFrom())
                         && isPastDateOrToday(this.getValidFrom()))) {
             return AddressType.CURRENT;
         }
 
-        return null;
+        return AddressType.PREVIOUS;
     }
 
     private ChronoLocalDate getDateToday() {

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/AddressTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/AddressTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 class AddressTest {
     @Test
@@ -25,9 +24,9 @@ class AddressTest {
     }
 
     @Test
-    void shouldReturnNullAddressTypeWhenValidFromAndValidUntilNotPresent() {
+    void shouldReturnPreviousAddressTypeWhenValidFromAndValidUntilNotPresent() {
         Address testAddress = new Address();
 
-        assertNull(testAddress.getAddressType());
+        assertEquals(AddressType.PREVIOUS, testAddress.getAddressType());
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Address getAddressType() will now only check for the pattern matching a CURRENT address.
All other addresses will be evaluated as PREVIOUS.

### Why did it change

FraudAPI is receiving a second address with null validFrom and null validUntil.
In the current processing this is evaluated to a null addressType, and the CRI cannot proceed.
This change is being done to ensure addressType gets populated in the Experian request for users who have multiple addresses.

### Issue tracking
- [KBV-771](https://govukverify.atlassian.net/browse/KBV-771)