### PR TITLE
KBV-795 Set secrets manager secret name prefix to env var 'SECRET_PREFIX'

### DIFF
--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java
@@ -28,7 +28,11 @@ class ConfigurationServiceTest {
     void setUp() {
         configurationService =
                 new ConfigurationService(
-                        mockSsmProvider, mockSecretsProvider, TEST_STACK_NAME, mockClock);
+                        mockSsmProvider,
+                        mockSecretsProvider,
+                        TEST_STACK_NAME,
+                        TEST_STACK_NAME,
+                        mockClock);
     }
 
     @Test
@@ -42,10 +46,28 @@ class ConfigurationServiceTest {
     }
 
     @Test
-    void shouldGetSecretValueByName() {
+    void shouldGetSecretValueByNameThatHasTheStackName() {
         String secretName = "my-secret-name";
         String secretValue = "secret-value";
         String fullSecretName = String.format(PARAM_NAME_FORMAT, TEST_STACK_NAME, secretName);
+        when(mockSecretsProvider.get(fullSecretName)).thenReturn(secretValue);
+        assertEquals(secretValue, configurationService.getSecretValue(secretName));
+        verify(mockSecretsProvider).get(fullSecretName);
+    }
+
+    @Test
+    void shouldGetSecretValueByNameThatTheSecretPrefixProvided() {
+        String secretPrefix = "customSecretPrefix";
+        configurationService =
+                new ConfigurationService(
+                        mockSsmProvider,
+                        mockSecretsProvider,
+                        TEST_STACK_NAME,
+                        secretPrefix,
+                        mockClock);
+        String secretName = "my-secret-name";
+        String secretValue = "secret-value";
+        String fullSecretName = String.format(PARAM_NAME_FORMAT, secretPrefix, secretName);
         when(mockSecretsProvider.get(fullSecretName)).thenReturn(secretValue);
         assertEquals(secretValue, configurationService.getSecretValue(secretName));
         verify(mockSecretsProvider).get(fullSecretName);


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Set secrets manager secret name prefix to env var `SECRET_PREFIX` and fall back to `AWS_STACK_NAME`.

Our lambdas currently expect to read secrets from a path that is prefaced with the stack name .e.g.

`/${AWS::StackName}/experian/iiq-url`

Change this to to:

`/${SecretPrefix}/experian/iiq-url`

where $SecretPrefix can be supplied as a parameter to the stack.

Also see https://github.com/alphagov/di-ipv-cri-kbv-api/pull/152

##  Why

To read secrets in secrets manager that have a default name across deployed stacks, so that these don’t have to be set per stack

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-795](https://govukverify.atlassian.net/browse/KBV-795)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks