### PR TITLE
KBV-771: Change Address getAddressType() to return CURRENT for null v…

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/Address.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/Address.java
@@ -153,14 +153,20 @@ public class Address {
 
     @JsonIgnore
     public AddressType getAddressType() {
-        if (Objects.nonNull(this.getValidUntil()) && isPastDate(this.getValidUntil())) {
-            return AddressType.PREVIOUS;
+
+        boolean validFromIsSpecified = Objects.nonNull(this.getValidFrom());
+        boolean validUntilIsSpecified = Objects.nonNull(this.getValidUntil());
+
+        if (!validUntilIsSpecified
+                && (!validFromIsSpecified || isPastDateOrToday(this.getValidFrom()))) {
+            return AddressType.CURRENT;
         }
 
-        if (Objects.isNull(this.getValidUntil())
-                && (Objects.nonNull(this.getValidFrom())
-                        && isPastDateOrToday(this.getValidFrom()))) {
-            return AddressType.CURRENT;
+        if ((validUntilIsSpecified && isPastDateOrToday(this.getValidUntil()))
+                && (!validFromIsSpecified
+                        || isPastDate(this.getValidFrom())
+                                && this.getValidUntil().isAfter(this.getValidFrom()))) {
+            return AddressType.PREVIOUS;
         }
 
         return null;

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/AddressTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/AddressTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 class AddressTest {
     @Test
-    void shouldGetPastAddressType() {
+    void shouldGetPreviousAddressTypeWhenValidUntilIsPastDate() {
         Address testAddress = new Address();
         testAddress.setValidUntil(LocalDate.of(2013, 8, 9));
 
@@ -17,7 +17,32 @@ class AddressTest {
     }
 
     @Test
-    void shouldGetCurrentAddressType() {
+    void shouldGetPreviousAddressTypeWithValidUntilIsToday() {
+        Address testAddress = new Address();
+        testAddress.setValidUntil(LocalDate.now());
+
+        assertEquals(AddressType.PREVIOUS, testAddress.getAddressType());
+    }
+
+    @Test
+    void shouldReturnNullAddressTypeWhenValidUntilIsInFuture() {
+        Address testAddress = new Address();
+        testAddress.setValidUntil(LocalDate.now().plusYears(1));
+
+        assertNull(testAddress.getAddressType());
+    }
+
+    @Test
+    void shouldGetPreviousAddressTypeWithValidUntilAndValidFrom() {
+        Address testAddress = new Address();
+        testAddress.setValidFrom(LocalDate.of(2013, 7, 9));
+        testAddress.setValidUntil(LocalDate.of(2013, 8, 9));
+
+        assertEquals(AddressType.PREVIOUS, testAddress.getAddressType());
+    }
+
+    @Test
+    void shouldGetCurrentAddressTypeWithValidFromInPast() {
         Address testAddress = new Address();
         testAddress.setValidFrom(LocalDate.of(2021, 9, 10));
 
@@ -25,8 +50,51 @@ class AddressTest {
     }
 
     @Test
-    void shouldReturnNullAddressTypeWhenValidFromAndValidUntilNotPresent() {
+    void shouldReturnCurrentAddressTypeWhenValidFromAndValidUntilAreNull() {
         Address testAddress = new Address();
+
+        assertEquals(AddressType.CURRENT, testAddress.getAddressType());
+    }
+
+    @Test
+    void shouldReturnCurrentAddressTypeWhenValidFromIsToday() {
+        Address testAddress = new Address();
+        testAddress.setValidFrom(LocalDate.now());
+
+        assertEquals(AddressType.CURRENT, testAddress.getAddressType());
+    }
+
+    @Test
+    void shouldReturnNullAddressTypeWhenValidFromIsInFuture() {
+        Address testAddress = new Address();
+        testAddress.setValidFrom(LocalDate.now().plusYears(1));
+
+        assertNull(testAddress.getAddressType());
+    }
+
+    @Test
+    void shouldReturnNullAddressTypeWhenValidFromAndValidUntilIsToday() {
+        Address testAddress = new Address();
+        testAddress.setValidFrom(LocalDate.now());
+        testAddress.setValidUntil(LocalDate.now());
+
+        assertNull(testAddress.getAddressType());
+    }
+
+    @Test
+    void shouldReturnNullAddressTypeWhenValidFromAndValidUntilAreInFuture() {
+        Address testAddress = new Address();
+        testAddress.setValidFrom(LocalDate.now().plusYears(1));
+        testAddress.setValidUntil(LocalDate.now().plusYears(2));
+
+        assertNull(testAddress.getAddressType());
+    }
+
+    @Test
+    void shouldReturnNullAddressTypeWhenValidFromAndValidUntilAreReversed() {
+        Address testAddress = new Address();
+        testAddress.setValidFrom(LocalDate.now().minusYears(1));
+        testAddress.setValidUntil(LocalDate.now().minusYears(2));
 
         assertNull(testAddress.getAddressType());
     }


### PR DESCRIPTION
## Proposed changes

### What changed

Several conditions added to Address getAddressType() with unit tests.

CURRENT AddressType
- null validFrom and null validUntil.
- validFrom with a past or todays date and null validUntil.

PREVIOUS AddressType
- validUntil with a past or todays date and null validFrom.
- validUntil with a past or todays date and validFrom that is a past date.

Null AddressType
- validFrom or validUntil with future dates.
- validFrom and validUntil are both todays date.
- validFrom is later than validUntil.

### Why did it change

FraudAPI is receiving a second address with null validFrom and null validUntil.
In the current processing this is evaluated to a null addressType but should evaluate to a CURRENT addressType.

In testing several more edge cases where found, such as when todays date is used for both fields, or a future date is entered, these are also covered.

### Issue tracking
- [LIME-61](https://govukverify.atlassian.net/browse/LIME-61) formerly [KBV-771](https://govukverify.atlassian.net/browse/KBV-771) 