### PR TITLE
LIME-45 Relay PersistentSessionId and ClientSessionId to AuditEventUser.

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEventUser.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEventUser.java
@@ -14,6 +14,12 @@ public class AuditEventUser {
     @JsonProperty("session_id")
     private String sessionId;
 
+    @JsonProperty("persistent_session_id")
+    private String persistentSessionId;
+
+    @JsonProperty("govuk_signin_journey_id")
+    private String clientSessionId;
+
     public String getUserId() {
         return userId;
     }
@@ -36,5 +42,21 @@ public class AuditEventUser {
 
     public void setSessionId(String sessionId) {
         this.sessionId = sessionId;
+    }
+
+    public String getPersistentSessionId() {
+        return persistentSessionId;
+    }
+
+    public void setPersistentSessionId(String persistentSessionId) {
+        this.persistentSessionId = persistentSessionId;
+    }
+
+    public String getClientSessionId() {
+        return clientSessionId;
+    }
+
+    public void setClientSessionId(String clientSessionId) {
+        this.clientSessionId = clientSessionId;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/SessionRequest.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/SessionRequest.java
@@ -20,6 +20,8 @@ public class SessionRequest {
     private String state;
     private SignedJWT signedJWT;
     private SharedClaims sharedClaims;
+    private String persistentSessionId;
+    private String clientSessionId;
 
     public String getIssuer() {
         return issuer;
@@ -119,5 +121,21 @@ public class SessionRequest {
 
     public boolean hasSharedClaims() {
         return Objects.nonNull(this.sharedClaims);
+    }
+
+    public String getPersistentSessionId() {
+        return persistentSessionId;
+    }
+
+    public void setPersistentSessionId(String persistentSessionId) {
+        this.persistentSessionId = persistentSessionId;
+    }
+
+    public String getClientSessionId() {
+        return clientSessionId;
+    }
+
+    public void setClientSessionId(String clientSessionId) {
+        this.clientSessionId = clientSessionId;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/SessionItem.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/SessionItem.java
@@ -22,6 +22,8 @@ public class SessionItem {
     private String accessToken;
     private long accessTokenExpiryDate;
     private String subject;
+    private String persistentSessionId;
+    private String clientSessionId;
 
     public SessionItem() {
         sessionId = UUID.randomUUID();
@@ -116,6 +118,22 @@ public class SessionItem {
 
     public void setCreatedDate(long createdDate) {
         this.createdDate = createdDate;
+    }
+
+    public String getPersistentSessionId() {
+        return persistentSessionId;
+    }
+
+    public void setPersistentSessionId(String persistentSessionId) {
+        this.persistentSessionId = persistentSessionId;
+    }
+
+    public String getClientSessionId() {
+        return clientSessionId;
+    }
+
+    public void setClientSessionId(String clientSessionId) {
+        this.clientSessionId = clientSessionId;
     }
 
     @Override

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactory.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactory.java
@@ -57,6 +57,8 @@ public class AuditEventFactory {
             userInfo = new AuditEventUser();
             userInfo.setSessionId(String.valueOf(sessionItem.getSessionId()));
             userInfo.setUserId(sessionItem.getSubject());
+            userInfo.setPersistentSessionId(sessionItem.getPersistentSessionId());
+            userInfo.setClientSessionId(sessionItem.getClientSessionId());
         }
 
         if (requestHeaders.containsKey(CLIENT_IP_HEADER_KEY)) {

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
@@ -53,6 +53,8 @@ public class SessionService {
         sessionItem.setClientId(sessionRequest.getClientId());
         sessionItem.setRedirectUri(sessionRequest.getRedirectUri());
         sessionItem.setSubject(sessionRequest.getSubject());
+        sessionItem.setPersistentSessionId(sessionRequest.getPersistentSessionId());
+        sessionItem.setClientSessionId(sessionRequest.getClientSessionId());
 
         dataStore.create(sessionItem);
 

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactoryTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/AuditEventFactoryTest.java
@@ -68,6 +68,8 @@ class AuditEventFactoryTest {
         long timestamp = 1656947224L;
         String userId = String.valueOf(UUID.randomUUID());
         UUID sessionId = UUID.randomUUID();
+        String persistentSessionId = UUID.randomUUID().toString();
+        String clientSessionId = UUID.randomUUID().toString();
         String clientIpAddress = "81.145.61.43";
         when(mockConfigurationService.getSqsAuditEventPrefix()).thenReturn(TEST_AUDIT_EVENT_PREFIX);
         when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(TEST_VC_ISSUER);
@@ -79,6 +81,8 @@ class AuditEventFactoryTest {
         SessionItem sessionItem = mock(SessionItem.class);
         when(sessionItem.getSubject()).thenReturn(userId);
         when(sessionItem.getSessionId()).thenReturn(sessionId);
+        when(sessionItem.getPersistentSessionId()).thenReturn(persistentSessionId);
+        when(sessionItem.getClientSessionId()).thenReturn(clientSessionId);
         AuditEventContext auditEventContext =
                 new AuditEventContext(personIdentity, requestHeaders, sessionItem);
         AuditEventFactory auditEventFactory =
@@ -94,6 +98,9 @@ class AuditEventFactoryTest {
         assertEquals(userId, auditEvent.getUser().getUserId());
         assertEquals(clientIpAddress, auditEvent.getUser().getIpAddress());
         assertEquals(String.valueOf(sessionId), auditEvent.getUser().getSessionId());
+        assertEquals(persistentSessionId, auditEvent.getUser().getPersistentSessionId());
+        assertEquals(clientSessionId, auditEvent.getUser().getClientSessionId());
+
         assertEquals(auditEventExtensions, auditEvent.getExtensions());
 
         verify(mockClock).instant();
@@ -127,6 +134,8 @@ class AuditEventFactoryTest {
         assertEquals(clientIpAddress, auditEvent.getUser().getIpAddress());
         assertNull(auditEvent.getUser().getUserId());
         assertNull(auditEvent.getUser().getSessionId());
+        assertNull(auditEvent.getUser().getPersistentSessionId());
+        assertNull(auditEvent.getUser().getClientSessionId());
         assertNull(auditEvent.getExtensions());
     }
 }

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/SessionServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/SessionServiceTest.java
@@ -70,6 +70,8 @@ class SessionServiceTest {
         when(sessionRequest.getRedirectUri())
                 .thenReturn(URI.create("https://www.example.com/callback"));
         when(sessionRequest.getSubject()).thenReturn("a subject");
+        when(sessionRequest.getPersistentSessionId()).thenReturn("a persistent session id");
+        when(sessionRequest.getClientSessionId()).thenReturn("a client session id");
 
         sessionService.saveSession(sessionRequest);
         verify(mockDataStore).create(sessionItemArgumentCaptor.capture());
@@ -79,6 +81,8 @@ class SessionServiceTest {
         assertThat(capturedValue.getClientId(), equalTo("a client id"));
         assertThat(capturedValue.getState(), equalTo("state"));
         assertThat(capturedValue.getSubject(), equalTo("a subject"));
+        assertThat(capturedValue.getPersistentSessionId(), equalTo("a persistent session id"));
+        assertThat(capturedValue.getClientSessionId(), equalTo("a client session id"));
         assertThat(
                 capturedValue.getRedirectUri(),
                 equalTo(URI.create("https://www.example.com/callback")));


### PR DESCRIPTION
## Proposed changes

### What changed

Relays PersistentSessionId and ClientSessionId from SessionService/SessionRequest to AuditService/AuditEventUser via SessionItem.

### Why did it change

The allows PersistentSessionId and ClientSessionId to appear in the user section of AuditEvents.

PersistentSessionId= "persistent_session_id"
ClientSessionId = "govuk_signin_journey_id" 
ClientSessionId follows [IPVAuthorisationService](https://github.com/alphagov/di-authentication-api/pull/2183/files) for variable naming.

Linked with [Common-Lamdas 20](https://github.com/alphagov/di-ipv-cri-common-lambdas/pull/20)

### Issue tracking

- [LIME-45](https://govukverify.atlassian.net/browse/LIME-45)
- [ADR-0039](https://github.com/alphagov/digital-identity-architecture/blob/main/adr/0039-govuk-signin-journey-id.md)
- [RFC-0023](https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0023-crossteam-audit-and-analysis-eventmessage-payload.md)