### PR TITLE
Add common-parameter-prefix to ConfigurationService

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -175,7 +175,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 apply plugin: 'io.github.gradle-nexus.publish-plugin'
 
-def buildVersion = "1.0.6"
+def buildVersion = "1.1.0"
 group = "uk.gov.account"
 version = "$buildVersion"
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityService.java
@@ -22,7 +22,8 @@ public class PersonIdentityService {
         this.personIdentityMapper = new PersonIdentityMapper();
         this.personIdentityDataStore =
                 new DataStore<>(
-                        configurationService.getParameterValue(PERSON_IDENTITY_TABLE_PARAM_NAME),
+                        configurationService.getCommonParameterValue(
+                                PERSON_IDENTITY_TABLE_PARAM_NAME),
                         PersonIdentityItem.class,
                         new DynamoDbEnhancedClientFactory().getClient());
     }
@@ -33,7 +34,8 @@ public class PersonIdentityService {
                 new PersonIdentityMapper(),
                 configurationService,
                 new DataStore<>(
-                        configurationService.getParameterValue(PERSON_IDENTITY_TABLE_PARAM_NAME),
+                        configurationService.getCommonParameterValue(
+                                PERSON_IDENTITY_TABLE_PARAM_NAME),
                         PersonIdentityItem.class,
                         new DynamoDbEnhancedClientFactory().getClient()));
     }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
@@ -27,7 +27,7 @@ public class SessionService {
         this.configurationService = new ConfigurationService();
         this.dataStore =
                 new DataStore<>(
-                        configurationService.getParameterValue(SESSION_TABLE_PARAM_NAME),
+                        configurationService.getCommonParameterValue(SESSION_TABLE_PARAM_NAME),
                         SessionItem.class,
                         new DynamoDbEnhancedClientFactory().getClient());
         this.clock = Clock.systemUTC();
@@ -38,7 +38,7 @@ public class SessionService {
     public SessionService(ConfigurationService configurationService) {
         this(
                 new DataStore<>(
-                        configurationService.getParameterValue(SESSION_TABLE_PARAM_NAME),
+                        configurationService.getCommonParameterValue(SESSION_TABLE_PARAM_NAME),
                         SessionItem.class,
                         new DynamoDbEnhancedClientFactory().getClient()),
                 configurationService,

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java
@@ -102,7 +102,7 @@ class ConfigurationServiceTest {
 
     @Test
     void shouldGetCommonParameterValueUsingCommonPrefix() {
-        String commonParamPrefix = "common-param-prefix";        
+        String commonParamPrefix = "common-param-prefix";
         configurationService =
                 new ConfigurationService(
                         mockSsmProvider,
@@ -112,15 +112,11 @@ class ConfigurationServiceTest {
                         TEST_STACK_NAME,
                         mockClock);
 
-        when(mockSsmProvider.get(
-                String.format(
-                        PARAM_NAME_FORMAT,
-                        commonParamPrefix,
-                        PARAM_NAME)))
+        when(mockSsmProvider.get(String.format(PARAM_NAME_FORMAT, commonParamPrefix, PARAM_NAME)))
                 .thenReturn(PARAM_VALUE);
         assertEquals(PARAM_VALUE, configurationService.getCommonParameterValue(PARAM_NAME));
-        verify(mockSsmProvider).get(
-                String.format(PARAM_NAME_FORMAT, commonParamPrefix, PARAM_NAME));
+        verify(mockSsmProvider)
+                .get(String.format(PARAM_NAME_FORMAT, commonParamPrefix, PARAM_NAME));
     }
 
     @Test


### PR DESCRIPTION
### What changed

- A `commonParameterPrefix` field has been added to the `ConfigurationService`.
- New methods `getCommonParameterValue` / `getParameterValueByAbsoluteName`
- The change has been made in a backwards compatible manner. The `commonParameterPrefix` field will default to the current stack name if the environment variable is not present.

### Why did it change
- This field will enable CRI-specific stacks to refer to SSM parameters that are prefixed with the common stack name.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-788](https://govukverify.atlassian.net/browse/OJ-788)

## Checklists

### Environment variables

- [ ] COMMON_PARAMETER_NAME_PREFIX (optional)
