### PR TITLE
OJ-887 Gradle task and AWS CodeBuild spec for publishing CRI common-libs to maven central

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-# di-ipv-cri-lib
-CRI common libraries
+# Credential Issuer common libraries
 
-This code runs inside its own Repo
+A library of common functions that can be used across credential issuers for validation, event transmission, describing common data etc.
 
+
+## Releasing CRI libs to Maven Central
+
+Update the `buildVersion` in `/build.gradle` to reflect the latest major, minor or patch version of this library.
+
+If this version is distinct, it should be deployed to Maven Central at [uk.gov.account:cri-common-lib](https://search.maven.org/artifact/uk.gov.account/cri-common-lib).

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id "org.sonarqube"
 	id "com.diffplug.spotless"
 	id "jacoco"
+	id "io.github.gradle-nexus.publish-plugin" version "1.0.0"
 }
 
 defaultTasks 'clean', 'spotlessApply', 'build'
@@ -30,6 +31,8 @@ repositories {
 java {
 	sourceCompatibility = JavaVersion.VERSION_11
 	targetCompatibility = JavaVersion.VERSION_11
+	withJavadocJar()
+	withSourcesJar()
 }
 
 
@@ -164,5 +167,71 @@ clean.doFirst {
 gradle.projectsEvaluated {
 	tasks.withType(JavaCompile) {
 		options.compilerArgs << "-Xlint:unchecked"
+	}
+}
+
+apply plugin: 'java-library'
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+apply plugin: 'io.github.gradle-nexus.publish-plugin'
+
+def buildVersion = "1.0.5"
+group = "uk.gov.account"
+version = "$buildVersion"
+
+nexusPublishing {
+	useStaging = true
+	repositories {
+		sonatype {
+			// because we registered in Sonatype after 24 Feb 2021, we provide these URIs
+			// see: https://github.com/gradle-nexus/publish-plugin/blob/master/README.md
+			nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+			snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+			username = System.getenv("SONATYPE_USERNAME")
+			password = System.getenv("SONATYPE_PASSWORD")
+		}
+	}
+}
+
+signing {
+	useInMemoryPgpKeys(
+			System.getenv("MAVEN_CENTRAL_SIGNING_KEY"),
+			System.getenv("MAVEN_CENTRAL_SIGNING_KEY_PASSWORD")
+			)
+	sign publishing.publications
+}
+
+publishing {
+	publications {
+		mavenJava(MavenPublication) {
+			from components.java
+			pom {
+				name = 'Digital Identity Credential Issuer common libraries'
+				packaging = 'jar'
+				description = 'Digital Identity Credential Issuer common libraries'
+				url = 'https://github.com/alphagov/di-ipv-cri-lib'
+				artifactId = 'cri-common-lib'
+
+				scm {
+					url = 'https://github.com/alphagov/di-ipv-cri-lib'
+					connection = 'scm:git:git://github.com/alphagov/di-ipv-cri-lib.git'
+					developerConnection = 'scm:git:ssh://git@github.com:alphagov/di-ipv-cri-lib.git'
+				}
+
+				licenses {
+					license {
+						name = 'MIT Licence'
+						url = 'https://github.com/alphagov/di-ipv-cri-lib/blob/main/LICENSE'
+						distribution = 'repo'
+					}
+				}
+
+				developers {
+					developer {
+						name = 'GDS Developers'
+					}
+				}
+			}
+		}
 	}
 }

--- a/deploy/buildspec.yaml
+++ b/deploy/buildspec.yaml
@@ -1,0 +1,16 @@
+version: 0.2
+
+env:
+  secrets-manager:
+    SONATYPE_USERNAME: "/publish-to-maven-central/sonatype_credentials:SONATYPE_USERNAME"
+    SONATYPE_PASSWORD: "/publish-to-maven-central/sonatype_credentials:SONATYPE_PASSWORD"
+    MAVEN_CENTRAL_SIGNING_KEY: "/publish-to-maven-central/maven_central_signing_key"
+    MAVEN_CENTRAL_SIGNING_KEY_PASSWORD: "/publish-to-maven-central/maven_central_signing_key_password"
+
+phases:
+  install:
+    runtime-versions:
+      java: corretto11
+  build:
+    commands:
+      - ./gradlew clean build publishToSonatype closeAndReleaseSonatypeStagingRepository


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

* Add a Gradle task to sign and publish CRI common-libs as a jar to maven central
* Add an AWS CodeBuild spec for run the gradle task above

Run the signing and publishing of common-cri-libs from within AWS in a CodePipeline, so we can store secrets like signing private keys and account credentials in AWS Secrets Manager.

This is preferred to storing these secrets in Github as repo secrets.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-887](https://govukverify.atlassian.net/browse/OJ-887)
