### PR TITLE
OJ-930 Save journey ids from CRI client to structured logging context

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,7 @@
+# Credential Issuer common libraries Release Notes
+
+
+## 1.1.1
+
+* Log `govuk_signin_journey_id` and `persistent_session_id` to CRI log messages.
+

--- a/build.gradle
+++ b/build.gradle
@@ -175,7 +175,8 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 apply plugin: 'io.github.gradle-nexus.publish-plugin'
 
-def buildVersion = "1.1.0"
+// please update RELEASE_NOTES.md when you update this version
+def buildVersion = "1.1.1"
 group = "uk.gov.account"
 version = "$buildVersion"
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.cri.common.library.service;
 
 import com.nimbusds.oauth2.sdk.token.AccessToken;
+import software.amazon.lambda.powertools.logging.LoggingUtils;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
 import uk.gov.di.ipv.cri.common.library.domain.SessionRequest;
 import uk.gov.di.ipv.cri.common.library.exception.AccessTokenExpiredException;
@@ -13,6 +14,7 @@ import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
 import uk.gov.di.ipv.cri.common.library.util.ListUtil;
 
 import java.time.Clock;
+import java.util.Optional;
 import java.util.UUID;
 
 public class SessionService {
@@ -74,6 +76,7 @@ public class SessionService {
     }
 
     public void updateSession(SessionItem sessionItem) {
+        setSessionItemsToLogging(sessionItem);
         dataStore.update(sessionItem);
     }
 
@@ -88,6 +91,7 @@ public class SessionService {
             throws SessionNotFoundException, SessionExpiredException {
 
         SessionItem sessionItem = dataStore.getItem(sessionId);
+        setSessionItemsToLogging(sessionItem);
         if (sessionItem == null) {
             throw new SessionNotFoundException("session not found");
         }
@@ -99,8 +103,14 @@ public class SessionService {
         return sessionItem;
     }
 
+    private void setSessionItemsToLogging(SessionItem sessionItem) {
+        Optional.ofNullable(sessionItem.getClientSessionId()).ifPresent(id -> LoggingUtils.appendKey("govuk_signin_journey_id", id));
+    }
+
     public SessionItem getSession(String sessionId) {
-        return dataStore.getItem(sessionId);
+        SessionItem sessionItem = dataStore.getItem(sessionId);
+        setSessionItemsToLogging(sessionItem);
+        return sessionItem;
     }
 
     public SessionItem getSessionByAccessToken(AccessToken accessToken)
@@ -124,6 +134,7 @@ public class SessionService {
 
         // Re-fetch our session directly to avoid problems with projections
         sessionItem = validateSessionId(String.valueOf(sessionItem.getSessionId()));
+        setSessionItemsToLogging(sessionItem);
 
         if (sessionItem.getAccessTokenExpiryDate() < clock.instant().getEpochSecond()) {
             throw new AccessTokenExpiredException("access code expired");
@@ -134,7 +145,7 @@ public class SessionService {
 
     public SessionItem getSessionByAuthorisationCode(String authCode)
             throws SessionExpiredException, AuthorizationCodeExpiredException,
-                    SessionNotFoundException {
+            SessionNotFoundException {
         SessionItem sessionItem;
 
         try {
@@ -153,6 +164,7 @@ public class SessionService {
 
         // Re-fetch our session directly to avoid problems with projections
         sessionItem = validateSessionId(String.valueOf(sessionItem.getSessionId()));
+        setSessionItemsToLogging(sessionItem);
 
         if (sessionItem.getAuthorizationCodeExpiryDate() < clock.instant().getEpochSecond()) {
             throw new AuthorizationCodeExpiredException("authorization code expired");

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/EventProbe.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/EventProbe.java
@@ -23,6 +23,13 @@ public class EventProbe {
         return this;
     }
 
+    public EventProbe log(Level level, String message) {
+        if (LOGGER.isEnabled(level)) {
+            LOGGER.log(level, message);
+        }
+        return this;
+    }
+
     private void logErrorCause(Throwable throwable) {
         Throwable cause = throwable.getCause();
         if (Objects.nonNull(cause)) {

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

We need to be able to track user journeys across auth, core and CRIs.

Save `govuk_signin_journey_id` and `persistent_session_id` to CRI log messages.

The conditions for this are:
* client like IPV Core has sent these ids in the Authorization JAR to a CRI
* the CRI has interacted with the session DynamoDB table during a lambda invocation
* The lambda is writing a log message or exception

A new method on EventProbe has also been added to allow us to log messages, not just exceptions.

Lambdas that use this version should set the `clearState` attribute on the `@Logging` annotation i.e. `@Logging(clearState = true ....)`

### What changed

Add govuk_signin_journey_id and persistent_session_id to structured log messages. 

### Why did it change

Help us with 2nd-line DI support to trace a user journey.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-930](https://govukverify.atlassian.net/browse/OJ-930)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks