### PR TITLE
LIME-125 - Moving Passport session items into common

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,14 @@
 # Credential Issuer common libraries Release Notes
 
+## 1.1.7
+
+* Added additional expiry time validation to auth jar checks
+* Added log helper to assist with adding logging identifiers
+
 ## 1.1.6
 
 * Added attemptCount to sessionItem and initialised attemptCount in session creation
-* Addded OathErrorResponse for use with access denied error
+* Added OathErrorResponse for use with access denied error
 
 ## 1.1.5
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "1.1.6"
+def buildVersion = "1.1.7"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/SessionRequest.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/SessionRequest.java
@@ -23,6 +23,7 @@ public class SessionRequest {
     private String persistentSessionId;
     private String clientSessionId;
     private String clientIpAddress;
+    private int attemptCount;
 
     public String getIssuer() {
         return issuer;
@@ -146,5 +147,13 @@ public class SessionRequest {
 
     public void setClientIpAddress(String clientIpAddress) {
         this.clientIpAddress = clientIpAddress;
+    }
+
+    public int getAttemptCount() {
+        return attemptCount;
+    }
+
+    public void setAttemptCount(int attemptCount) {
+        this.attemptCount = attemptCount;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/SessionRequest.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/SessionRequest.java
@@ -23,7 +23,6 @@ public class SessionRequest {
     private String persistentSessionId;
     private String clientSessionId;
     private String clientIpAddress;
-    private int attemptCount;
 
     public String getIssuer() {
         return issuer;
@@ -147,13 +146,5 @@ public class SessionRequest {
 
     public void setClientIpAddress(String clientIpAddress) {
         this.clientIpAddress = clientIpAddress;
-    }
-
-    public int getAttemptCount() {
-        return attemptCount;
-    }
-
-    public void setAttemptCount(int attemptCount) {
-        this.attemptCount = attemptCount;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/helper/LogHelper.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/helper/LogHelper.java
@@ -1,0 +1,75 @@
+package uk.gov.di.ipv.cri.common.library.helper;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.cloudwatchlogs.emf.util.StringUtils;
+import software.amazon.lambda.powertools.logging.LoggingUtils;
+import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public class LogHelper {
+    private static final Logger LOGGER = LogManager.getLogger();
+    public static final String COMPONENT_ID = "passport-cri";
+    public static final String GOVUK_SIGNIN_JOURNEY_ID_DEFAULT_VALUE = "unknown";
+
+    public enum LogField {
+        CLIENT_ID_LOG_FIELD("clientId"),
+        COMPONENT_ID_LOG_FIELD("componentId"),
+        ERROR_CODE_LOG_FIELD("errorCode"),
+        ERROR_DESCRIPTION_LOG_FIELD("errorDescription"),
+        PASSPORT_SESSION_ID_LOG_FIELD("passportSessionId"),
+        GOVUK_SIGNIN_JOURNEY_ID("govuk_signin_journey_id"),
+        JTI_LOG_FIELD("jti"),
+        USED_AT_DATE_TIME_LOG_FIELD("usedAtDateTime");
+
+        private final String fieldName;
+
+        LogField(String fieldName) {
+            this.fieldName = fieldName;
+        }
+
+        public String getFieldName() {
+            return this.fieldName;
+        }
+    }
+
+    private LogHelper() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static void attachComponentIdToLogs() {
+        attachFieldToLogs(LogField.COMPONENT_ID_LOG_FIELD, COMPONENT_ID);
+    }
+
+    public static void attachClientIdToLogs(String clientId) {
+        attachFieldToLogs(LogField.CLIENT_ID_LOG_FIELD, clientId);
+    }
+
+    public static void attachPassportSessionIdToLogs(String sessionId) {
+        attachFieldToLogs(LogField.PASSPORT_SESSION_ID_LOG_FIELD, sessionId);
+    }
+
+    public static void attachGovukSigninJourneyIdToLogs(String govukSigninJourneyId) {
+        if (StringUtils.isNullOrEmpty(govukSigninJourneyId)) {
+            attachFieldToLogs(
+                    LogField.GOVUK_SIGNIN_JOURNEY_ID, GOVUK_SIGNIN_JOURNEY_ID_DEFAULT_VALUE);
+        } else {
+            attachFieldToLogs(LogField.GOVUK_SIGNIN_JOURNEY_ID, govukSigninJourneyId);
+        }
+    }
+
+    public static void logOauthError(String message, String errorCode, String errorDescription) {
+        LoggingUtils.appendKey(LogField.ERROR_CODE_LOG_FIELD.getFieldName(), errorCode);
+        LoggingUtils.appendKey(
+                LogField.ERROR_DESCRIPTION_LOG_FIELD.getFieldName(), errorDescription);
+        LOGGER.error(message);
+        LoggingUtils.removeKeys(
+                LogField.ERROR_CODE_LOG_FIELD.getFieldName(),
+                LogField.ERROR_DESCRIPTION_LOG_FIELD.getFieldName());
+    }
+
+    private static void attachFieldToLogs(LogField field, String value) {
+        LoggingUtils.appendKey(field.getFieldName(), value);
+        LOGGER.info("{} attached to logs", field);
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/JWTVerifier.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/JWTVerifier.java
@@ -29,6 +29,7 @@ import java.text.ParseException;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Map;
 import java.util.Set;
@@ -77,11 +78,12 @@ public class JWTVerifier {
     public void validateMaxAllowedJarTtl(Instant jwtExpirationTime, long maxAllowedTtl)
             throws SessionValidationException {
 
-        LocalDateTime maximumExpirationTime = LocalDateTime.now().plusSeconds(maxAllowedTtl);
+        LocalDateTime maximumExpirationTime =
+                LocalDateTime.ofInstant(
+                        Instant.now().plus(maxAllowedTtl, ChronoUnit.SECONDS), ZoneOffset.UTC);
         LocalDateTime expirationTime = LocalDateTime.ofInstant(jwtExpirationTime, ZoneOffset.UTC);
 
         if (expirationTime.isAfter(maximumExpirationTime)) {
-            LOGGER.error("Client JWT expiry date is too far in the future");
             throw new SessionValidationException(
                     "The client JWT expiry date has surpassed the maximum allowed ttl value");
         }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/JWTVerifier.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/JWTVerifier.java
@@ -13,8 +13,6 @@ import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.jwt.proc.BadJWTException;
 import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
 import com.nimbusds.oauth2.sdk.id.ClientID;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.cri.common.library.exception.ClientConfigurationException;
 import uk.gov.di.ipv.cri.common.library.exception.SessionValidationException;
 
@@ -37,8 +35,6 @@ import java.util.Set;
 import static com.nimbusds.jose.JWSAlgorithm.ES256;
 
 public class JWTVerifier {
-
-    private static final Logger LOGGER = LogManager.getLogger();
 
     public void verifyAuthorizationJWT(
             Map<String, String> clientAuthenticationConfig, SignedJWT signedJWT)

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/JWTVerifierTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/JWTVerifierTest.java
@@ -22,6 +22,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.text.ParseException;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Date;
@@ -102,6 +103,29 @@ class JWTVerifierTest {
         assertEquals(
                 "JWT iss claim has value incorrect-issuer-url, must be ipv-core-stub",
                 exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowValidationExceptionWhenJWTClaimsExpiryExceedsLimit() {
+        SessionValidationException exception =
+                assertThrows(
+                        SessionValidationException.class,
+                        () ->
+                                jwtVerifier.validateMaxAllowedJarTtl(
+                                        Instant.now()
+                                                .plusSeconds(101)
+                                                .atZone(ZoneId.of("UTC"))
+                                                .toInstant(),
+                                        100));
+        assertEquals(
+                "The client JWT expiry date has surpassed the maximum allowed ttl value",
+                exception.getMessage());
+    }
+
+    @Test
+    void shouldNotThrowValidationExceptionWhenJWTClaimsWithinLimit() {
+        jwtVerifier.validateMaxAllowedJarTtl(
+                Instant.now().plusSeconds(99).atZone(ZoneId.of("UTC")).toInstant(), 100);
     }
 
     @Test

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/SessionServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/SessionServiceTest.java
@@ -96,6 +96,7 @@ class SessionServiceTest {
         assertThat(
                 capturedValue.getRedirectUri(),
                 equalTo(URI.create("https://www.example.com/callback")));
+        assertThat(capturedValue.getAttemptCount(), equalTo(0));
     }
 
     @Test


### PR DESCRIPTION
### What changed

Shifted passport sessionItem functionality and fields into common library, for integration of passport cri into common

### Why did it change

So that passport session can be handled by common

### Issue tracking

- [LIME-125](https://govukverify.atlassian.net/browse/LIME-125)
