### PR TITLE
OJ-924: Save client ip address provided to /session API call

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 1.1.3
+
+* Added `clientIpAddress` in session table `session-di-ipv-cri-kbv-*`.
+
 ## 1.1.2
 
 * Remove `persistent_session_id` from being logged.

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "1.1.2"
+def buildVersion = "1.1.3"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/SessionRequest.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/SessionRequest.java
@@ -22,6 +22,7 @@ public class SessionRequest {
     private SharedClaims sharedClaims;
     private String persistentSessionId;
     private String clientSessionId;
+    private String clientIpAddress;
 
     public String getIssuer() {
         return issuer;
@@ -137,5 +138,13 @@ public class SessionRequest {
 
     public void setClientSessionId(String clientSessionId) {
         this.clientSessionId = clientSessionId;
+    }
+
+    public String getClientIpAddress() {
+        return clientIpAddress;
+    }
+
+    public void setClientIpAddress(String clientIpAddress) {
+        this.clientIpAddress = clientIpAddress;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/SessionItem.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/SessionItem.java
@@ -24,6 +24,7 @@ public class SessionItem {
     private String subject;
     private String persistentSessionId;
     private String clientSessionId;
+    private String clientIpAddress;
 
     public SessionItem() {
         sessionId = UUID.randomUUID();
@@ -134,6 +135,14 @@ public class SessionItem {
 
     public void setClientSessionId(String clientSessionId) {
         this.clientSessionId = clientSessionId;
+    }
+
+    public String getClientIpAddress() {
+        return clientIpAddress;
+    }
+
+    public void setClientIpAddress(String clientIpAddress) {
+        this.clientIpAddress = clientIpAddress;
     }
 
     @Override

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
@@ -70,7 +70,9 @@ public class SessionService {
         sessionItem.setSubject(sessionRequest.getSubject());
         sessionItem.setPersistentSessionId(sessionRequest.getPersistentSessionId());
         sessionItem.setClientSessionId(sessionRequest.getClientSessionId());
+        sessionItem.setClientIpAddress(sessionRequest.getClientIpAddress());
         setSessionItemsToLogging(sessionItem);
+
         dataStore.create(sessionItem);
         return sessionItem.getSessionId();
     }

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/SessionServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/SessionServiceTest.java
@@ -76,6 +76,7 @@ class SessionServiceTest {
         when(sessionRequest.getSubject()).thenReturn("a subject");
         when(sessionRequest.getPersistentSessionId()).thenReturn("a persistent session id");
         when(sessionRequest.getClientSessionId()).thenReturn("a client session id");
+        when(sessionRequest.getClientIpAddress()).thenReturn("192.0.2.0");
 
         try (MockedStatic<LoggingUtils> loggingUtilsMockedStatic =
                 Mockito.mockStatic(LoggingUtils.class)) {
@@ -91,6 +92,7 @@ class SessionServiceTest {
         assertThat(capturedValue.getSubject(), equalTo("a subject"));
         assertThat(capturedValue.getPersistentSessionId(), equalTo("a persistent session id"));
         assertThat(capturedValue.getClientSessionId(), equalTo("a client session id"));
+        assertThat(capturedValue.getClientIpAddress(), equalTo("192.0.2.0"));
         assertThat(
                 capturedValue.getRedirectUri(),
                 equalTo(URI.create("https://www.example.com/callback")));


### PR DESCRIPTION
## Proposed changes

Save Client Ip Address to session-di-ipv-cri-kbv-* Table. 

### What changed

created new column in  session-di-ipv-cri-kbv-* Table and save the IP address from session.

### Why did it change

To reuse IP address of client to send to TXMA.

### Issue tracking

- [OJ-924](https://govukverify.atlassian.net/browse/OJ-924)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks