### PR TITLE
OJ-957 Cache SSM params and secrets for longer

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -131,21 +131,21 @@
         "filename": "src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java",
         "hashed_secret": "e240bcbe3b4f29f2766077de121a9397f55d7df3",
         "is_verified": false,
-        "line_number": 71
+        "line_number": 72
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java",
         "hashed_secret": "dbdab9be92cacdae6a97e8601332bfaa8545800f",
         "is_verified": false,
-        "line_number": 72
+        "line_number": 73
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java",
         "hashed_secret": "d7ef6e16f0d4b09bcb3f82b02054988b9790aa0b",
         "is_verified": false,
-        "line_number": 81
+        "line_number": 82
       }
     ],
     "src/test/java/uk/gov/di/ipv/cri/common/library/service/JWTVerifierTest.java": [
@@ -209,5 +209,5 @@
       }
     ]
   },
-  "generated_at": "2022-09-22T20:54:15Z"
+  "generated_at": "2022-09-23T07:44:12Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -73,6 +73,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -127,21 +131,21 @@
         "filename": "src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java",
         "hashed_secret": "e240bcbe3b4f29f2766077de121a9397f55d7df3",
         "is_verified": false,
-        "line_number": 51
+        "line_number": 71
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java",
         "hashed_secret": "dbdab9be92cacdae6a97e8601332bfaa8545800f",
         "is_verified": false,
-        "line_number": 52
+        "line_number": 72
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java",
         "hashed_secret": "d7ef6e16f0d4b09bcb3f82b02054988b9790aa0b",
         "is_verified": false,
-        "line_number": 61
+        "line_number": 81
       }
     ],
     "src/test/java/uk/gov/di/ipv/cri/common/library/service/JWTVerifierTest.java": [
@@ -205,5 +209,5 @@
       }
     ]
   },
-  "generated_at": "2022-09-20T12:18:10Z"
+  "generated_at": "2022-09-22T20:54:15Z"
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 1.1.4
+
+* Performance: cache SSM params and Secrets Manager secrets for longer
+
 ## 1.1.3
 
 * Added `clientIpAddress` in session table `session-di-ipv-cri-kbv-*`.

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,9 @@ dependencies {
 			"org.junit.jupiter:junit-jupiter-params:${dependencyVersions.junit}",
 			"org.mockito:mockito-junit-jupiter:${dependencyVersions.mockito}",
 			"org.mockito:mockito-inline:${dependencyVersions.mockito}",
-			"org.hamcrest:hamcrest:2.2"
+			"org.hamcrest:hamcrest:2.2",
+			"uk.org.webcompere:system-stubs-jupiter:2.0.1",
+			"uk.org.webcompere:system-stubs-core:2.0.1"
 
 	test_runtime "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit}"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "1.1.3"
+def buildVersion = "1.1.4"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationService.java
@@ -20,6 +20,7 @@ public class ConfigurationService {
     private static final String PARAMETER_NAME_FORMAT = "/%s/%s";
     private static final long DEFAULT_BEARER_TOKEN_TTL_IN_SECS = 3600L;
     private static final Long AUTHORIZATION_CODE_TTL_IN_SECS = 600L;
+    public static final String CONFIG_SERVICE_CACHE_TTL_MINS = "CONFIG_SERVICE_CACHE_TTL_MINS";
     private final SSMProvider ssmProvider;
     private final SecretsProvider secretsProvider;
     private final String parameterPrefix;
@@ -171,7 +172,7 @@ public class ConfigurationService {
     }
 
     private static int getCacheTTLInMinutes() {
-        return Optional.ofNullable(System.getenv("CONFIG_SERVICE_CACHE_TTL_MINS"))
+        return Optional.ofNullable(System.getenv(CONFIG_SERVICE_CACHE_TTL_MINS))
                 .map(Integer::valueOf)
                 .orElse(5);
     }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationService.java
@@ -45,15 +45,17 @@ public class ConfigurationService {
     public ConfigurationService() {
         this(
                 ParamManager.getSsmProvider(
-                        SsmClient.builder()
-                                .region(Region.of(System.getenv("AWS_REGION")))
-                                .httpClient(UrlConnectionHttpClient.create())
-                                .build()),
+                                SsmClient.builder()
+                                        .region(Region.of(System.getenv("AWS_REGION")))
+                                        .httpClient(UrlConnectionHttpClient.create())
+                                        .build())
+                        .defaultMaxAge(getCacheTTLInMinutes(), ChronoUnit.MINUTES),
                 ParamManager.getSecretsProvider(
-                        SecretsManagerClient.builder()
-                                .region(Region.of(System.getenv("AWS_REGION")))
-                                .httpClient(UrlConnectionHttpClient.create())
-                                .build()),
+                                SecretsManagerClient.builder()
+                                        .region(Region.of(System.getenv("AWS_REGION")))
+                                        .httpClient(UrlConnectionHttpClient.create())
+                                        .build())
+                        .defaultMaxAge(getCacheTTLInMinutes(), ChronoUnit.MINUTES),
                 System.getenv("AWS_STACK_NAME"),
                 System.getenv("COMMON_PARAMETER_NAME_PREFIX"),
                 Optional.ofNullable(System.getenv("SECRET_PREFIX"))
@@ -166,5 +168,11 @@ public class ConfigurationService {
 
     private String getCommonParameterPrefix() {
         return Objects.nonNull(commonParameterPrefix) ? commonParameterPrefix : parameterPrefix;
+    }
+
+    private static int getCacheTTLInMinutes() {
+        return Optional.ofNullable(System.getenv("CONFIG_SERVICE_CACHE_TTL_MINS"))
+                .map(Integer::valueOf)
+                .orElse(5);
     }
 }

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.cri.common.library.service.ConfigurationService.CONFIG_SERVICE_CACHE_TTL_MINS;
 
 @ExtendWith({MockitoExtension.class, SystemStubsExtension.class})
 class ConfigurationServiceTest {
@@ -154,9 +155,9 @@ class ConfigurationServiceTest {
 
     @Test
     @DisplayName(
-            "should cache ssm params and secrets manager secrets for 1 minute if set by the env var CONFIG_MAX_AGE_IN_MINS")
+            "should cache ssm params and secrets manager secrets for 1 minute if set by the env var " + CONFIG_SERVICE_CACHE_TTL_MINS)
     void cacheForMinutesSetByEnvVar() {
-        environment.set("CONFIG_SERVICE_CACHE_TTL_MINS", "1");
+        environment.set(CONFIG_SERVICE_CACHE_TTL_MINS, "1");
         testConfigurationManagerWithExpectedCacheMinutes(1);
     }
 

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java
@@ -149,15 +149,15 @@ class ConfigurationServiceTest {
 
     @Test
     @DisplayName("should cache ssm params and secrets manager secrets for 5 minutes by default")
-    void cacheFor5MinsByDefault() {
+    void shouldCacheFor5MinsByDefault() {
         testConfigurationManagerWithExpectedCacheMinutes(5);
     }
 
     @Test
     @DisplayName(
-            "should cache ssm params and secrets manager secrets for 1 minute if set by the env var "
+            "should cache ssm params and secrets manager secrets for the number of minutes set by the env var "
                     + CONFIG_SERVICE_CACHE_TTL_MINS)
-    void cacheForMinutesSetByEnvVar() {
+    void shouldCacheForMinutesSetByEnvVar() {
         environment.set(CONFIG_SERVICE_CACHE_TTL_MINS, "1");
         testConfigurationManagerWithExpectedCacheMinutes(1);
     }

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java
@@ -155,7 +155,8 @@ class ConfigurationServiceTest {
 
     @Test
     @DisplayName(
-            "should cache ssm params and secrets manager secrets for 1 minute if set by the env var " + CONFIG_SERVICE_CACHE_TTL_MINS)
+            "should cache ssm params and secrets manager secrets for 1 minute if set by the env var "
+                    + CONFIG_SERVICE_CACHE_TTL_MINS)
     void cacheForMinutesSetByEnvVar() {
         environment.set(CONFIG_SERVICE_CACHE_TTL_MINS, "1");
         testConfigurationManagerWithExpectedCacheMinutes(1);

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java
@@ -1,21 +1,37 @@
 package uk.gov.di.ipv.cri.common.library.service;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.SsmClientBuilder;
+import software.amazon.lambda.powertools.parameters.ParamManager;
 import software.amazon.lambda.powertools.parameters.SSMProvider;
 import software.amazon.lambda.powertools.parameters.SecretsProvider;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, SystemStubsExtension.class})
 class ConfigurationServiceTest {
     private static final String TEST_STACK_NAME = "stack-name";
     private static final String PARAM_NAME_FORMAT = "/%s/%s";
@@ -25,6 +41,10 @@ class ConfigurationServiceTest {
     @Mock private SecretsProvider mockSecretsProvider;
     @Mock private Clock mockClock;
     private ConfigurationService configurationService;
+
+    @SystemStub
+    private EnvironmentVariables environment =
+            new EnvironmentVariables("AWS_REGION", "eu-west-2", "AWS_STACK_NAME", "my-stack-name");
 
     @BeforeEach
     void setUp() {
@@ -124,5 +144,63 @@ class ConfigurationServiceTest {
         when(mockSsmProvider.get(PARAM_NAME)).thenReturn(PARAM_VALUE);
         assertEquals(PARAM_VALUE, configurationService.getParameterValueByAbsoluteName(PARAM_NAME));
         verify(mockSsmProvider).get(PARAM_NAME);
+    }
+
+    @Test
+    @DisplayName("should cache ssm params and secrets manager secrets for 5 minutes by default")
+    void cacheFor5MinsByDefault() {
+        testConfigurationManagerWithExpectedCacheMinutes(5);
+    }
+
+    @Test
+    @DisplayName(
+            "should cache ssm params and secrets manager secrets for 1 minute if set by the env var CONFIG_MAX_AGE_IN_MINS")
+    void cacheForMinutesSetByEnvVar() {
+        environment.set("CONFIG_SERVICE_CACHE_TTL_MINS", "1");
+        testConfigurationManagerWithExpectedCacheMinutes(1);
+    }
+
+    private void testConfigurationManagerWithExpectedCacheMinutes(int expectedMinutes) {
+        try (MockedStatic<ParamManager> mockStaticParamManager = mockStatic(ParamManager.class);
+                MockedStatic<SsmClient> mockStaticSsmClient = mockStatic(SsmClient.class);
+                MockedStatic<SecretsManagerClient> mockStaticSecretsManagerClient =
+                        mockStatic(SecretsManagerClient.class)) {
+
+            {
+                SsmClientBuilder mockSsmClientBuilder = mock(SsmClientBuilder.class);
+                mockStaticSsmClient.when(SsmClient::builder).thenReturn(mockSsmClientBuilder);
+                SsmClient mockSsmClient = mock(SsmClient.class);
+                when(mockSsmClientBuilder.region(Region.EU_WEST_2))
+                        .thenReturn(mockSsmClientBuilder);
+                when(mockSsmClientBuilder.httpClient(any(UrlConnectionHttpClient.class)))
+                        .thenReturn(mockSsmClientBuilder);
+                when(mockSsmClientBuilder.build()).thenReturn(mockSsmClient);
+                mockStaticParamManager
+                        .when(() -> ParamManager.getSsmProvider(mockSsmClient))
+                        .thenReturn(mockSsmProvider);
+            }
+
+            {
+                SecretsManagerClientBuilder mockSecretsManagerClientBuilder =
+                        mock(SecretsManagerClientBuilder.class);
+                SecretsManagerClient mockSecretsManagerClient = mock(SecretsManagerClient.class);
+                mockStaticSecretsManagerClient
+                        .when(SecretsManagerClient::builder)
+                        .thenReturn(mockSecretsManagerClientBuilder);
+                when(mockSecretsManagerClientBuilder.region(Region.EU_WEST_2))
+                        .thenReturn(mockSecretsManagerClientBuilder);
+                when(mockSecretsManagerClientBuilder.httpClient(any(UrlConnectionHttpClient.class)))
+                        .thenReturn(mockSecretsManagerClientBuilder);
+                when(mockSecretsManagerClientBuilder.build()).thenReturn(mockSecretsManagerClient);
+                mockStaticParamManager
+                        .when(() -> ParamManager.getSecretsProvider(mockSecretsManagerClient))
+                        .thenReturn(mockSecretsProvider);
+            }
+
+            new ConfigurationService();
+
+            verify(mockSsmProvider).defaultMaxAge(expectedMinutes, ChronoUnit.MINUTES);
+            verify(mockSecretsProvider).defaultMaxAge(expectedMinutes, ChronoUnit.MINUTES);
+        }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

We identified that too much lambda time is spent looking up SSM params and Secrets Manager secrets, as the current [powertools](https://awslabs.github.io/aws-lambda-powertools-java/utilities/parameters/) cache TTL is 5 seconds. We want to cache params and secrets for a longer time, and make our lambdas run faster.

### What changed

This fix is to increase this timeout to 5 minutes by default, and set the value explicitly via the env var `CONFIG_SERVICE_CACHE_TTL_MINS`.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-957](https://govukverify.atlassian.net/browse/OJ-957)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks