### PR TITLE
OJ-982: Update vc signature to concat format

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 1.1.5
+
+* Convert the KMS der signature format into concat format
+
 ## 1.1.4
 
 * Performance: cache SSM params and Secrets Manager secrets for longer

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "1.1.4"
+def buildVersion = "1.1.5"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 


### PR DESCRIPTION


## Proposed changes

### What changed

Convert the KMS der signature format into concat format.

### Why did it change

By default KMS the signature is in DER format. We have being using this and this is currently incompatible with the specs. The correct format should be R||S format (aka CONCAT format) this PR is ensure compatibility 


### Issue tracking
Related
[DCP-343](https://govukverify.atlassian.net/browse/DCP-343)


- [OJ-982](https://govukverify.atlassian.net/browse/OJ-982)
