### PR TITLE
LIME-147 - Adding dlRetry and OauthErrorResponse to common lib

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Credential Issuer common libraries Release Notes
 
+## 1.1.6
+
+* Added attemptCount to sessionItem and initialised attemptCount in session creation
+* Addded OathErrorResponse for use with access denied error
+
+## 1.1.5
+
+* Convert the KMS der signature format into concat format
+
 ## 1.1.4
 
 * Performance: cache SSM params and Secrets Manager secrets for longer

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "1.1.4"
+def buildVersion = "1.1.6"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/error/OauthErrorResponse.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/error/OauthErrorResponse.java
@@ -1,0 +1,31 @@
+package uk.gov.di.ipv.cri.common.library.error;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum OauthErrorResponse {
+    ACCESS_DENIED_ERROR("access_denied", "Authorization permission denied");
+
+    private final String code;
+    private final String message;
+
+    OauthErrorResponse(
+            @JsonProperty(required = true, value = "error") String code,
+            @JsonProperty(required = true, value = "error_description") String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getErrorSummary() {
+        return getCode() + ": " + getMessage();
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/SessionItem.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/SessionItem.java
@@ -25,6 +25,7 @@ public class SessionItem {
     private String persistentSessionId;
     private String clientSessionId;
     private String clientIpAddress;
+    private int attemptCount;
 
     public SessionItem() {
         sessionId = UUID.randomUUID();
@@ -143,6 +144,14 @@ public class SessionItem {
 
     public void setClientIpAddress(String clientIpAddress) {
         this.clientIpAddress = clientIpAddress;
+    }
+
+    public int getAttemptCount() {
+        return attemptCount;
+    }
+
+    public void setAttemptCount(int attemptCount) {
+        this.attemptCount = attemptCount;
     }
 
     @Override

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/SessionService.java
@@ -71,6 +71,7 @@ public class SessionService {
         sessionItem.setPersistentSessionId(sessionRequest.getPersistentSessionId());
         sessionItem.setClientSessionId(sessionRequest.getClientSessionId());
         sessionItem.setClientIpAddress(sessionRequest.getClientIpAddress());
+        sessionItem.setAttemptCount(0);
         setSessionItemsToLogging(sessionItem);
 
         dataStore.create(sessionItem);


### PR DESCRIPTION
### What changed

added dlAttemptCount to sessionItem in order to track attempts in drivingLicenceCri, also added OauthErrorResponse class for returning accessDenied error to IpvCore when a user escapes their journey.

### Why did it change

For integration with Driving licence Cri and for escape route error handling