### PR TITLE
LIME-126 - Move functionality from Passport CRI access token lambda to shared CRI access token lambda 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ configurations {
 	gson
 	powertools
 	mockito
+	commons_codec
 }
 
 // The dynamodb enhanced package loads the apache-client as well as the spi-client, so
@@ -102,6 +103,8 @@ dependencies {
 			"uk.org.webcompere:system-stubs-core:2.0.1"
 
 	test_runtime "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit}"
+
+	commons_codec "commons-codec:commons-codec:1.15"
 }
 
 dependencies {
@@ -113,7 +116,8 @@ dependencies {
 			configurations.nimbus,
 			configurations.powertools,
 			configurations.sqs,
-			configurations.kms
+			configurations.kms,
+			configurations.commons_codec
 
 	testImplementation configurations.tests
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/helpers/LogHelper.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/helpers/LogHelper.java
@@ -1,0 +1,75 @@
+package uk.gov.di.ipv.cri.common.library.helpers;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.cloudwatchlogs.emf.util.StringUtils;
+import software.amazon.lambda.powertools.logging.LoggingUtils;
+import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@ExcludeFromGeneratedCoverageReport
+public class LogHelper {
+    private static final Logger LOGGER = LogManager.getLogger();
+    public static final String COMPONENT_ID = "passport-cri";
+    public static final String GOVUK_SIGNIN_JOURNEY_ID_DEFAULT_VALUE = "unknown";
+
+    public enum LogField {
+        CLIENT_ID_LOG_FIELD("clientId"),
+        COMPONENT_ID_LOG_FIELD("componentId"),
+        ERROR_CODE_LOG_FIELD("errorCode"),
+        ERROR_DESCRIPTION_LOG_FIELD("errorDescription"),
+        PASSPORT_SESSION_ID_LOG_FIELD("passportSessionId"),
+        GOVUK_SIGNIN_JOURNEY_ID("govuk_signin_journey_id"),
+        JTI_LOG_FIELD("jti"),
+        USED_AT_DATE_TIME_LOG_FIELD("usedAtDateTime");
+
+        private final String fieldName;
+
+        LogField(String fieldName) {
+            this.fieldName = fieldName;
+        }
+
+        public String getFieldName() {
+            return this.fieldName;
+        }
+    }
+
+    private LogHelper() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static void attachComponentIdToLogs() {
+        attachFieldToLogs(LogField.COMPONENT_ID_LOG_FIELD, COMPONENT_ID);
+    }
+
+    public static void attachClientIdToLogs(String clientId) {
+        attachFieldToLogs(LogField.CLIENT_ID_LOG_FIELD, clientId);
+    }
+
+    public static void attachPassportSessionIdToLogs(String sessionId) {
+        attachFieldToLogs(LogField.PASSPORT_SESSION_ID_LOG_FIELD, sessionId);
+    }
+
+    public static void attachGovukSigninJourneyIdToLogs(String govukSigninJourneyId) {
+        if (StringUtils.isNullOrEmpty(govukSigninJourneyId)) {
+            attachFieldToLogs(
+                    LogField.GOVUK_SIGNIN_JOURNEY_ID, GOVUK_SIGNIN_JOURNEY_ID_DEFAULT_VALUE);
+        } else {
+            attachFieldToLogs(LogField.GOVUK_SIGNIN_JOURNEY_ID, govukSigninJourneyId);
+        }
+    }
+
+    public static void logOauthError(String message, String errorCode, String errorDescription) {
+        LoggingUtils.appendKey(LogField.ERROR_CODE_LOG_FIELD.getFieldName(), errorCode);
+        LoggingUtils.appendKey(
+                LogField.ERROR_DESCRIPTION_LOG_FIELD.getFieldName(), errorDescription);
+        LOGGER.error(message);
+        LoggingUtils.removeKeys(
+                LogField.ERROR_CODE_LOG_FIELD.getFieldName(),
+                LogField.ERROR_DESCRIPTION_LOG_FIELD.getFieldName());
+    }
+
+    private static void attachFieldToLogs(LogField field, String value) {
+        LoggingUtils.appendKey(field.getFieldName(), value);
+        LOGGER.info("{} attached to logs", field);
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/DynamodbItem.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/DynamodbItem.java
@@ -1,0 +1,5 @@
+package uk.gov.di.ipv.cri.common.library.persistence.item;
+
+public interface DynamodbItem {
+    void setTtl(long ttl);
+}

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/SessionItem.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/SessionItem.java
@@ -8,7 +8,7 @@ import java.net.URI;
 import java.util.UUID;
 
 @DynamoDbBean
-public class SessionItem {
+public class SessionItem implements DynamodbItem {
     public static final String AUTHORIZATION_CODE_INDEX = "authorizationCode-index";
     public static final String ACCESS_TOKEN_INDEX = "access-token-index";
     private UUID sessionId;
@@ -26,6 +26,13 @@ public class SessionItem {
     private String clientSessionId;
     private String clientIpAddress;
     private int attemptCount;
+    private String authorizationCodeUsedAtTime;
+    private String accessTokenExchangedDateTime;
+    private String accessTokenRevokedDateTime;
+    private String jwtId;
+    private String jwtIdUsedAt;
+
+    private long ttl;
 
     public SessionItem() {
         sessionId = UUID.randomUUID();
@@ -152,6 +159,55 @@ public class SessionItem {
 
     public void setAttemptCount(int attemptCount) {
         this.attemptCount = attemptCount;
+    }
+
+    public String getAuthorizationCodeUsedAtTime() {
+        return authorizationCodeUsedAtTime;
+    }
+
+    public void setAuthorizationCodeUsedAtTime(String authorizationCodeUsedAtTime) {
+        this.authorizationCodeUsedAtTime = authorizationCodeUsedAtTime;
+    }
+
+    public String getAccessTokenExchangedDateTime() {
+        return accessTokenExchangedDateTime;
+    }
+
+    public void setAccessTokenExchangedDateTime(String accessTokenExchangedDateTime) {
+        this.accessTokenExchangedDateTime = accessTokenExchangedDateTime;
+    }
+
+    public String getAccessTokenRevokedDateTime() {
+        return accessTokenRevokedDateTime;
+    }
+
+    public void setAccessTokenRevokedDateTime(String accessTokenRevokedDateTime) {
+        this.accessTokenRevokedDateTime = accessTokenRevokedDateTime;
+    }
+
+    public long getTtl() {
+        return ttl;
+    }
+
+    @Override
+    public void setTtl(long ttl) {
+        this.ttl = ttl;
+    }
+
+    public String getJwtId() {
+        return jwtId;
+    }
+
+    public void setJwtId(String jwtId) {
+        this.jwtId = jwtId;
+    }
+
+    public String getJwtIdUsedAt() {
+        return jwtIdUsedAt;
+    }
+
+    public void setJwtIdUsedAt(String jwtIdUsedAt) {
+        this.jwtIdUsedAt = jwtIdUsedAt;
     }
 
     @Override

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationService.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationService.java
@@ -4,6 +4,7 @@ import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.SsmException;
 import software.amazon.lambda.powertools.parameters.ParamManager;
 import software.amazon.lambda.powertools.parameters.SSMProvider;
 import software.amazon.lambda.powertools.parameters.SecretsProvider;
@@ -132,7 +133,12 @@ public class ConfigurationService {
     }
 
     public long getMaxJwtTtl() {
-        return Long.parseLong(ssmProvider.get(getParameterName(SSMParameterName.MAXIMUM_JWT_TTL)));
+        try {
+            return Long.parseLong(
+                    ssmProvider.get(getParameterName(SSMParameterName.MAXIMUM_JWT_TTL)));
+        } catch (SsmException e) {
+            return 7200l;
+        }
     }
 
     public String getVerifiableCredentialIssuer() {

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServicePublicKeySelector.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServicePublicKeySelector.java
@@ -1,0 +1,77 @@
+package uk.gov.di.ipv.cri.common.library.service;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import com.nimbusds.oauth2.sdk.auth.Secret;
+import com.nimbusds.oauth2.sdk.auth.verifier.ClientCredentialsSelector;
+import com.nimbusds.oauth2.sdk.auth.verifier.Context;
+import com.nimbusds.oauth2.sdk.auth.verifier.InvalidClientException;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+
+import java.io.ByteArrayInputStream;
+import java.security.PublicKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.text.ParseException;
+import java.util.Base64;
+import java.util.List;
+
+public class ConfigurationServicePublicKeySelector implements ClientCredentialsSelector<Object> {
+
+    private final ConfigurationService configurationService;
+
+    public ConfigurationServicePublicKeySelector(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+    }
+
+    @Override
+    public List<Secret> selectClientSecrets(
+            ClientID claimedClientID, ClientAuthenticationMethod authMethod, Context context) {
+        throw new UnsupportedOperationException("We don't do that round here...");
+    }
+
+    @Override
+    public List<? extends PublicKey> selectPublicKeys(
+            ClientID claimedClientID,
+            ClientAuthenticationMethod authMethod,
+            JWSHeader jwsHeader,
+            boolean forceRefresh,
+            Context context)
+            throws InvalidClientException {
+        try {
+            return List.of(
+                    getPublicKeyFromConfig(
+                            configurationService
+                                    .getParametersForPath(
+                                            "/clients/"
+                                                    + claimedClientID.getValue()
+                                                    + "/jwtAuthentication")
+                                    .get("publicSigningJwkBase64"),
+                            jwsHeader.getAlgorithm()));
+        } catch (ParseException | JOSEException | CertificateException e) {
+            throw new InvalidClientException(e.getMessage());
+        }
+    }
+
+    private PublicKey getPublicKeyFromConfig(
+            String serialisedPublicKey, JWSAlgorithm signingAlgorithm)
+            throws CertificateException, ParseException, JOSEException {
+        if (JWSAlgorithm.Family.RSA.contains(signingAlgorithm)) {
+            byte[] binaryCertificate = Base64.getDecoder().decode(serialisedPublicKey);
+            CertificateFactory factory = CertificateFactory.getInstance("X.509");
+            Certificate certificate =
+                    factory.generateCertificate(new ByteArrayInputStream(binaryCertificate));
+            return certificate.getPublicKey();
+        } else if (JWSAlgorithm.Family.EC.contains(signingAlgorithm)) {
+            return ECKey.parse(new String(Base64.getDecoder().decode(serialisedPublicKey)))
+                    .toECPublicKey();
+        } else {
+            throw new IllegalArgumentException(
+                    "Unexpected signing algorithm encountered: " + signingAlgorithm.getName());
+        }
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/persistence/DataStoreTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/persistence/DataStoreTest.java
@@ -11,6 +11,7 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 
 import java.util.UUID;
 
@@ -26,6 +27,7 @@ class DataStoreTest {
 
     @Mock private DynamoDbEnhancedClient mockDynamoDbEnhancedClient;
     @Mock private DynamoDbTable<SessionItem> mockDynamoDbTable;
+    @Mock private ConfigurationService mockConfigurationService;
 
     private SessionItem sessionItem;
     private DataStore<SessionItem> dataStore;
@@ -35,11 +37,17 @@ class DataStoreTest {
         when(mockDynamoDbEnhancedClient.table(
                         anyString(), ArgumentMatchers.<TableSchema<SessionItem>>any()))
                 .thenReturn(mockDynamoDbTable);
+        when(mockConfigurationService.getSessionTtl()).thenReturn(100l);
 
         sessionItem = new SessionItem();
         String accessToken = UUID.randomUUID().toString();
 
-        dataStore = new DataStore<>(TEST_TABLE_NAME, SessionItem.class, mockDynamoDbEnhancedClient);
+        dataStore =
+                new DataStore<>(
+                        TEST_TABLE_NAME,
+                        SessionItem.class,
+                        mockDynamoDbEnhancedClient,
+                        mockConfigurationService);
     }
 
     @Test

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/AccessTokenServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/AccessTokenServiceTest.java
@@ -1,28 +1,34 @@
 package uk.gov.di.ipv.cri.common.library.service;
 
+import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jwt.SignedJWT;
-import com.nimbusds.oauth2.sdk.AccessTokenResponse;
-import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
-import com.nimbusds.oauth2.sdk.OAuth2Error;
-import com.nimbusds.oauth2.sdk.TokenRequest;
-import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.*;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthentication;
+import com.nimbusds.oauth2.sdk.auth.ClientSecretBasic;
 import com.nimbusds.oauth2.sdk.auth.JWTAuthentication;
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
+import com.nimbusds.oauth2.sdk.auth.Secret;
 import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import com.nimbusds.oauth2.sdk.token.Tokens;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
+import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.exception.AccessTokenRequestException;
 import uk.gov.di.ipv.cri.common.library.exception.AccessTokenValidationException;
 import uk.gov.di.ipv.cri.common.library.exception.ClientConfigurationException;
 import uk.gov.di.ipv.cri.common.library.exception.SessionValidationException;
+import uk.gov.di.ipv.cri.common.library.persistence.DataStore;
 import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
 
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.ParseException;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -32,10 +38,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -44,15 +48,22 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AccessTokenServiceTest {
+    private static final String TEST_TABLE_NAME = "test-auth-code-table";
+    @Mock private DataStore<SessionItem> mockDataStore;
     @Mock private ConfigurationService mockConfigurationService;
     @Mock private JWTVerifier mockJwtVerifier;
     @InjectMocks private AccessTokenService accessTokenService;
 
     private final String SAMPLE_JWT =
-            "eyJraWQiOiJpcHYtY29yZS1zdHViIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJpcHYtY29yZS1zdHViIiwiYXVkIjoiaHR0cHM6XC9cL2Rldi5hZGRyZXNzLmNyaS5hY2NvdW50Lmdvdi51ayIsIm5iZiI6MTY1MDU0MTg0MCwic2hhcmVkX2NsYWltcyI6eyJhZGRyZXNzZXMiOlt7InN0cmVldDEiOiI4Iiwic3RyZWV0MiI6IkhBRExFWSBST0FEIiwidG93bkNpdHkiOiJCQVRIIiwiY3VycmVudEFkZHJlc3MiOnRydWUsInBvc3RDb2RlIjoiQkEyIDVBQSJ9XSwibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ2YWx1ZSI6IktFTk5FVEgiLCJ0eXBlIjoiR2l2ZW5OYW1lIn0seyJ2YWx1ZSI6IkRFQ0VSUVVFSVJBIiwidHlwZSI6IkZhbWlseU5hbWUifV19XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5NjQtMDktMTkifV0sIkBjb250ZXh0IjpbImh0dHBzOlwvXC93d3cudzMub3JnXC8yMDE4XC9jcmVkZW50aWFsc1wvdjEiLCJodHRwczpcL1wvdm9jYWIubG9uZG9uLmNsb3VkYXBwcy5kaWdpdGFsXC9jb250ZXh0c1wvaWRlbnRpdHktdjEuanNvbmxkIl19LCJpc3MiOiJpcHYtY29yZS1zdHViIiwicmVkaXJlY3RfdXJpIjoiaHR0cHM6XC9cL2RpLWlwdi1jb3JlLXN0dWIubG9uZG9uLmNsb3VkYXBwcy5kaWdpdGFsXC9jYWxsYmFjayIsImV4cCI6MTY1MDU0NTQ0MCwiaWF0IjoxNjUwNTQxODQwLCJqdGkiOiJmNzM0ZTZjZi0xODVhLTQ3N2YtYjQxMi02YWU5ZTc0ODk5NzUifQ.lhizSFXqbQaBXwpnuanI4Ze69B4MSSoqfZLiDDVA7EEwuJSMx9ooB8zFUJORo7SWX-L-qGtM6vjGNhM7GGOLKxZhOZbES7UQu3D7ES5CpNiyZOAUVXnGDEISINF1bYJupS3ujbPfIkOMMoWdWxBpcVzh1TELpzqiYGAeMlSZUmZnIf5i8juysJi8C_DUKklnlF-iGUsCKjXfdNkDz4sx5VYnQu1rDckPUSsK0XKVcxu9lU7cqx39iNuqmkLgsgK1RvG6f1xIOJPUGm2HBfjzM8ZeV3zYlYU5Xa1umlfVptVPrcxMZEm6Iy-cH7d_1XqO1yXFTEzUdDlGL6UlKK7B1T2nAjBCP9YPhh59JQOohu2RnC6gz-kVHisJEPzYp3mAthLJ2KzeYk1BEDRbZo7jWQzYaVXoNgG_gCfDtep5aTKudDtkPtIWFJ3ENEvC2sItXNEFcKQrKkBBcvSmRy8DJE9A3mpPOTp6GaaNrONwbfRvjgcDSDew0i4_mw6Rg-GA0k10nQ874KRjpowzouTJvNCI1CYALIghUD-xNkC7N4TA0zHNiq2eeSI089LdVIsSz_tsGg4YZOKk7HVqmnm81lkeXBfIsUGkH3weI6f4kXZOFQr6YCu5bDqDXgzmSf0ocxprwf1b-OhzWGRmKluSJRMs2hU2Q8-AIVtG5NxrCGE";
+            "eyJraWQiOiJpcHYtY29yZS1zdHViLTItZnJvbS1ta2p3ay5vcmciLCJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJpcHYtY29yZS1zdHViIiwic2hhcmVkX2NsYWltcyI6eyJAY29udGV4dCI6WyJodHRwczpcL1wvd3d3LnczLm9yZ1wvMjAxOFwvY3JlZGVudGlhbHNcL3YxIiwiaHR0cHM6XC9cL3ZvY2FiLmxvbmRvbi5jbG91ZGFwcHMuZGlnaXRhbFwvY29udGV4dHNcL2lkZW50aXR5LXYxLmpzb25sZCJdLCJuYW1lIjpbeyJuYW1lUGFydHMiOlt7InR5cGUiOiJHaXZlbk5hbWUiLCJ2YWx1ZSI6Ik1JQ0hFTExFIn0seyJ0eXBlIjoiRmFtaWx5TmFtZSIsInZhbHVlIjoiS0FCSVIifV19XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5ODEtMDctMjgifV0sImFkZHJlc3MiOlt7ImJ1aWxkaW5nTnVtYmVyIjpudWxsLCJidWlsZGluZ05hbWUiOiJQRVJJR1JBVEgiLCJzdHJlZXROYW1lIjoiUElUU1RSVUFOIFRFUlJBQ0UiLCJhZGRyZXNzTG9jYWxpdHkiOiJBQkVSREVFTiIsInBvc3RhbENvZGUiOiJBQjEwIDZRVyIsInZhbGlkRnJvbSI6IjIwMjEtMDEtMDEiLCJ2YWxpZFVudGlsIjpudWxsfV19LCJpc3MiOiJpcHYtY29yZS1zdHViIiwicGVyc2lzdGVudF9zZXNzaW9uX2lkIjoiZjMxMTZiNzYtOTVjMy00Y2RmLWI1OGUtZTAzNDE2NTIwMmY4IiwicmVzcG9uc2VfdHlwZSI6ImNvZGUiLCJjbGllbnRfaWQiOiJpcHYtY29yZS1zdHViIiwiZ292dWtfc2lnbmluX2pvdXJuZXlfaWQiOiI4YzAzNmI5NC03YTE1LTQ1MmYtOGViZC04MTMzYjY4ZjMwZjAiLCJhdWQiOiJpcHYtY29yZSIsIm5iZiI6MTY2NTU5NzI5MSwic2NvcGUiOiJvcGVuaWQiLCJyZWRpcmVjdF91cmkiOiJodHRwOlwvXC9sb2NhbGhvc3Q6ODA4NVwvY2FsbGJhY2siLCJzdGF0ZSI6Ilc5c2EteHR1ZWkwZHNxcWxvdllQTExYUzZEUi1uZGZYQmRtb2xlZU1uUHciLCJleHAiOjE2NzA3ODEyOTEsImlhdCI6MTY2NTU5NzI5MSwianRpIjoiOTU1MzE3YTctMzg0ZC00YmIxLTlkNmItYzM0Y2RkMTAxNWZjIn0.QZJ8hpZ8ghYd0fQlhCj-o24XQATK7lQHjWOe_waldHsgJ1RTvqSb9tk-6nrB_qCFCz-UpkCc1mSGSArmFE7l3w";
 
     private final String JWT_MISSING_JTI =
             "eyJraWQiOiJpcHYtY29yZS1zdHViIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJpcHYtY29yZS1zdHViIiwiYXVkIjoiaHR0cHM6XC9cL2Rldi5hZGRyZXNzLmNyaS5hY2NvdW50Lmdvdi51ayIsIm5iZiI6MTY1MDU0MDkyNSwic2hhcmVkX2NsYWltcyI6eyJAY29udGV4dCI6WyJodHRwczpcL1wvd3d3LnczLm9yZ1wvMjAxOFwvY3JlZGVudGlhbHNcL3YxIiwiaHR0cHM6XC9cL3ZvY2FiLmxvbmRvbi5jbG91ZGFwcHMuZGlnaXRhbFwvY29udGV4dHNcL2lkZW50aXR5LXYxLmpzb25sZCJdLCJhZGRyZXNzZXMiOlt7InN0cmVldDEiOiI4Iiwic3RyZWV0MiI6IkhBRExFWSBST0FEIiwidG93bkNpdHkiOiJCQVRIIiwiY3VycmVudEFkZHJlc3MiOnRydWUsInBvc3RDb2RlIjoiQkEyIDVBQSJ9XSwibmFtZSI6W3sibmFtZVBhcnRzIjpbeyJ2YWx1ZSI6IktFTk5FVEgiLCJ0eXBlIjoiR2l2ZW5OYW1lIn0seyJ2YWx1ZSI6IkRFQ0VSUVVFSVJBIiwidHlwZSI6IkZhbWlseU5hbWUifV19XSwiYmlydGhEYXRlIjpbeyJ2YWx1ZSI6IjE5NjQtMDktMTkifV19LCJpc3MiOiJpcHYtY29yZS1zdHViIiwicmVkaXJlY3RfdXJpIjoiaHR0cHM6XC9cL2RpLWlwdi1jb3JlLXN0dWIubG9uZG9uLmNsb3VkYXBwcy5kaWdpdGFsXC9jYWxsYmFjayIsImV4cCI6MTY1MDU0NDUyNSwiaWF0IjoxNjUwNTQwOTI1fQ.qbT49i9CPImPMXj7_U_W5IKmqlyAMidXWcVajMxEsFmPvQCbfkGDJYUun2dnKeyUpkTNXdxBRgTjrl0ZyODxnaIrW4ZZD3dzm-9EoMoFFHKtttmYiucyVM65ZnCaDDu3IUVQulZ-5ADX8bn-pghIqd95NDE_oM8HDlGExcdtZuwOK-fPI4txABGPbgGV6it3HoXaeZr1JyLzJHunTM6mnYOvi50GULh0VPGDsOgNC5Mf61JPkzBvHJbnS9WcKzFIpl7zyfbyDJ9WWl5G88fBdErSjFdI5R0-gc3Cy3m3QYm76dwDfFZax7inbKnK1yyC8cBb8mvr3f5M9s6Mmckd9KFBymYid8M0acTbQi5XPBxOmIr0zeJZ85YQxtyvKswpASoWT6ap-VmglfBQ6MQ0Ql6VydLyYOuo4ZFLNX3uOD4TDEf-TCVKLO2sL3-GEQ4gZP59lHXQr4LD8aGnp_ikWLXBDk2toGcfXcUfA6Ph-67rKWjtDYYqanh4fqM-3dUmUVBkbq0341dHl_Y5igdvkxu7Gbj9X64sdurHE_ALnBTUHyMnjWLfbu_WmYM3qq4CHVrjNw-TgpQZxHHxhHJkUPmVn_gsoaVyb2TPAvecQ0iDbXhzXVR3Jw0tlhZgDtfz-8zEZyae5g6DRMsd6mWMhCx8LFWcsJtbm4_OCQ_Y6zU";
+
+    @BeforeEach
+    void setUp() {
+        this.accessTokenService = new AccessTokenService(mockConfigurationService, mockJwtVerifier);
+    }
 
     @Test
     void shouldThrowExceptionForMissingJTI()
@@ -258,16 +269,11 @@ class AccessTokenServiceTest {
         when(accessTokenResponse.getTokens()).thenReturn(mockTokens);
         BearerAccessToken mockBearerAccessToken = mock(BearerAccessToken.class);
         when(mockTokens.getBearerAccessToken()).thenReturn(mockBearerAccessToken);
-        when(mockBearerAccessToken.toAuthorizationHeader()).thenReturn("some-authorization-header");
+        when(mockBearerAccessToken.getValue()).thenReturn("some-authorization-header");
         accessTokenService.updateSessionAccessToken(sessionItem, accessTokenResponse);
 
-        assertThat(
-                sessionItem.getAccessToken(),
-                equalTo(
-                        accessTokenResponse
-                                .getTokens()
-                                .getBearerAccessToken()
-                                .toAuthorizationHeader()));
+        assertEquals(
+                sessionItem.getAccessToken(), DigestUtils.sha256Hex("some-authorization-header"));
 
         assertNull(sessionItem.getAuthorizationCode());
 
@@ -294,6 +300,10 @@ class AccessTokenServiceTest {
             map.put("redirectUri", "https://www.example/com/callback");
             map.put("authenticationAlg", "RS256");
             map.put("issuer", "ipv-core");
+            map.put("audience", "ipv-core");
+            map.put(
+                    "publicSigningJwkBase64",
+                    "ewogICAgImt0eSI6ICJFQyIsCiAgICAidXNlIjogInNpZyIsCiAgICAiY3J2IjogIlAtMjU2IiwKICAgICJraWQiOiAiaXB2LWNvcmUtc3R1Yi0yLWZyb20tbWtqd2sub3JnIiwKICAgICJ4IjogImszOXVLYWNTdWtRQnJNWnJIRFRCVVpzbGl2cFhLRE5aVGc2aW5DSHdyTGMiLAogICAgInkiOiAiOEY4TG5RN3dHOWh4c1Q0YXgwQXR5N2lNR0l5aVlfWUdwM19xSVp6S28xQSIsCiAgICAiYWxnIjogIkVTMjU2Igp9");
             return map;
         } catch (Exception e) {
             throw new IllegalStateException(e);
@@ -303,7 +313,8 @@ class AccessTokenServiceTest {
     @Test
     void shouldValidateTokenRequestSuccessfully()
             throws AccessTokenValidationException, SessionValidationException,
-                    ClientConfigurationException {
+                    ClientConfigurationException, ParseException,
+                    com.nimbusds.oauth2.sdk.ParseException, JOSEException {
 
         String authCodeValue = "12345";
         String grantType = "authorization_code";
@@ -333,6 +344,8 @@ class AccessTokenServiceTest {
         sessionItem.setClientId(clientID);
         sessionItem.setRedirectUri(URI.create("https://www.example/com/callback"));
 
+        when(mockJwtVerifier.clientJwtWithConcatSignature(any(), anyMap()))
+                .thenReturn(privateKeyJWT);
         when(mockConfigurationService.getParametersForPath(
                         "/clients/" + clientID + "/jwtAuthentication"))
                 .thenReturn(getSSMConfigMap());
@@ -417,7 +430,7 @@ class AccessTokenServiceTest {
         assertThat(
                 exception.getMessage(),
                 containsString(
-                        "Invalid private key JWT authentication: The client identifier doesn't match the client assertion subject / issuer"));
+                        "Invalid private key JWT authentication: The client identifier doesn't match the client assertion subject"));
         verify(mockJwtVerifier, never()).verifyAccessTokenJWT(any(), any(), any());
     }
 
@@ -478,5 +491,89 @@ class AccessTokenServiceTest {
                 containsString(
                         "Invalid client_assertion JWT: Invalid serialized unsecured/JWS/JWE object: Missing part delimiters"));
         verify(mockJwtVerifier, never()).verifyAccessTokenJWT(any(), any(), any());
+    }
+
+    @Test
+    void shouldReturnSuccessfulTokenResponseOnSuccessfulExchange() throws URISyntaxException {
+        long testTokenTtl = 2400L;
+        when(mockConfigurationService.getBearerAccessTokenTtl()).thenReturn(testTokenTtl);
+
+        AuthorizationCode code = new AuthorizationCode("xyz...");
+        URI callback = new URI("https://client.com/callback");
+        AuthorizationGrant codeGrant = new AuthorizationCodeGrant(code, callback);
+
+        ClientID clientID = new ClientID("123");
+        Secret clientSecret = new Secret("secret");
+        ClientAuthentication clientAuth = new ClientSecretBasic(clientID, clientSecret);
+
+        URI tokenEndpoint = new URI("https://c2id.com/token");
+
+        TokenRequest request = new TokenRequest(tokenEndpoint, clientAuth, codeGrant);
+        TokenResponse response = accessTokenService.createToken(request);
+
+        assertInstanceOf(AccessTokenResponse.class, response);
+        assertNotNull(response.toSuccessResponse().getTokens().getAccessToken().getValue());
+        assertEquals(
+                testTokenTtl,
+                response.toSuccessResponse().getTokens().getBearerAccessToken().getLifetime());
+    }
+
+    @Test
+    void shouldReturnValidationErrorWhenInvalidGrantTypeProvided() {
+        TokenRequest tokenRequest =
+                new TokenRequest(
+                        URI.create("http://gds"), new RefreshTokenGrant(new RefreshToken()));
+
+        AccessTokenValidationException exception =
+                assertThrows(
+                        AccessTokenValidationException.class,
+                        () ->
+                                accessTokenService.validateTokenRequest(
+                                        tokenRequest, new SessionItem()));
+
+        assertNotNull(exception);
+        AccessTokenRequestException cause = (AccessTokenRequestException) exception.getCause();
+        assertEquals(OAuth2Error.INVALID_GRANT, cause.getErrorObject());
+    }
+
+    @Test
+    void shouldPersistAccessToken() {
+        AccessToken accessToken = new BearerAccessToken(3600L, null);
+        AccessTokenResponse accessTokenResponse =
+                new AccessTokenResponse(new Tokens(accessToken, null));
+
+        SessionItem sessionItem = new SessionItem();
+        accessTokenService.updateSessionAccessToken(sessionItem, accessTokenResponse);
+
+        assertNotNull(sessionItem);
+        assertEquals(
+                DigestUtils.sha256Hex(
+                        accessTokenResponse.getTokens().getBearerAccessToken().getValue()),
+                sessionItem.getAccessToken());
+        assertNotNull(sessionItem.getAccessTokenExpiryDate());
+    }
+
+    @Test
+    void shouldRevokeAccessToken() {
+        String accessToken = "test-access-token";
+
+        SessionItem sessionItem = new SessionItem();
+        sessionItem.setAccessToken(accessToken);
+
+        accessTokenService.revokeAccessToken(sessionItem);
+
+        assertNotNull(sessionItem.getAccessTokenRevokedDateTime());
+    }
+
+    @Test
+    void shouldNotAttemptUpdateIfSessionNoLongerExists() {
+        String accessToken = "test-access-token";
+
+        SessionItem sessionItem = null;
+
+        IllegalArgumentException exception =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> accessTokenService.revokeAccessToken(sessionItem));
     }
 }

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/JWTVerifierTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/JWTVerifierTest.java
@@ -301,10 +301,12 @@ class JWTVerifierTest {
                 new SignedJWT(
                         new JWSHeader.Builder(JWSAlgorithm.RS256).build(),
                         new JWTClaimsSet.Builder()
+                                .issueTime(Date.from(now.minus(1, ChronoUnit.HOURS)))
                                 .issuer("https://dev.core.ipv.account.gov.uk")
                                 .subject(UUID.randomUUID().toString())
                                 .audience("https://address.cri.account.gov.uk")
                                 .expirationTime(Date.from(now.plus(1, ChronoUnit.HOURS)))
+                                .claim("response_type", "code")
                                 .build());
         RSASSASigner rsaSigner = new RSASSASigner(getPrivateKey());
         signedJWT.sign(rsaSigner);

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/SessionServiceTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/SessionServiceTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.cri.common.library.service;
 
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -132,7 +133,7 @@ class SessionServiceTest {
     void shouldGetSessionItemByTokenIndexSuccessfully()
             throws AccessTokenExpiredException, SessionExpiredException, SessionNotFoundException {
         AccessToken accessToken = new BearerAccessToken();
-        String serialisedAccessToken = accessToken.toAuthorizationHeader();
+        String serialisedAccessToken = DigestUtils.sha256Hex(accessToken.getValue());
         SessionItem item = new SessionItem();
         item.setSessionId(UUID.randomUUID());
         item.setAccessToken(serialisedAccessToken);
@@ -196,7 +197,7 @@ class SessionServiceTest {
     @Test
     void shouldThrowAccessTokenExpiredException() {
         AccessToken accessToken = new BearerAccessToken();
-        String serialisedAccessToken = accessToken.toAuthorizationHeader();
+        String serialisedAccessToken = DigestUtils.sha256Hex(accessToken.getValue());
         SessionItem item = new SessionItem();
         item.setSessionId(UUID.randomUUID());
         item.setAccessToken(serialisedAccessToken);

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/KMSSignerTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/KMSSignerTest.java
@@ -1,11 +1,12 @@
 package uk.gov.di.ipv.cri.common.library.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSObject;
 import com.nimbusds.jose.Payload;
-import com.nimbusds.jose.shaded.json.JSONObject;
 import com.nimbusds.jose.util.Base64URL;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -93,14 +94,14 @@ class KMSSignerTest {
 
     @Test
     void shouldSignJWSObject()
-            throws JOSEException, NoSuchAlgorithmException, SignatureException,
-                    InvalidKeyException {
+            throws JOSEException, NoSuchAlgorithmException, SignatureException, InvalidKeyException,
+                    JsonProcessingException {
         var signResponse = mock(SignResponse.class);
         when(mockKmsClient.sign(any(SignRequest.class))).thenReturn(signResponse);
         when(signResponse.signature())
                 .thenReturn(SdkBytes.fromByteArray(getDERPayloadBytes("test payload".getBytes())));
 
-        JSONObject jsonPayload = new JSONObject(Map.of("test", "test"));
+        String jsonPayload = new ObjectMapper().writeValueAsString(Map.of("test", "test"));
 
         JWSHeader jwsHeader = new JWSHeader.Builder(ES256).build();
         JWSObject jwsObject = new JWSObject(jwsHeader, new Payload(jsonPayload));
@@ -109,7 +110,7 @@ class KMSSignerTest {
 
         assertEquals(JWSObject.State.SIGNED, jwsObject.getState());
         assertEquals(jwsHeader, jwsObject.getHeader());
-        assertEquals(jsonPayload.toJSONString(), jwsObject.getPayload().toString());
+        assertEquals(jsonPayload, jwsObject.getPayload().toString());
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

### What changed

Updated so that
* Default ttl values are applied to the session
* access token value is hashed in the db
* access tokens can be set as revoked
* utilised nimbus verifications on jwt

### Why did it change

To align with passport and follow the best practice listed here
https://docs.google.com/spreadsheets/d/1CEC4xYgyLcijDKeZm8GhZrRNDKsgLFHPRymOxJWJIao/edit?pli=1#gid=363396808

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-126](https://govukverify.atlassian.net/browse/LIME-126)

