### PR TITLE
OJ-976 - Add common VC JWT claims set builder

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 1.2.0
+
+* Added VerifiableCredentialClaimsSetBuilder class to centralise the creation of the verifiable credential JWT claims set
+
 ## 1.1.8
 
 * Code smells removal (no functional change)

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "1.1.8"
+def buildVersion = "1.2.0"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilder.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilder.java
@@ -1,0 +1,140 @@
+package uk.gov.di.ipv.cri.common.library.util;
+
+import com.nimbusds.jwt.JWTClaimNames;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class VerifiableCredentialClaimsSetBuilder {
+    private final ConfigurationService configurationService;
+    private final Clock clock;
+
+    private Object verifiableCredentialSubject;
+    private String verifiableCredentialType;
+    private String[] contexts;
+    private String subject;
+    private Object evidence;
+    private ChronoUnit ttlUnit;
+    private long ttl;
+
+    public VerifiableCredentialClaimsSetBuilder(
+            ConfigurationService configurationService, Clock clock) {
+        this.configurationService = configurationService;
+        this.clock = clock;
+    }
+
+    public VerifiableCredentialClaimsSetBuilder subject(String subject) {
+        if (StringUtils.isBlank(subject)) {
+            throw new IllegalArgumentException("The subject must not be null or empty.");
+        }
+        this.subject = subject;
+        return this;
+    }
+
+    public VerifiableCredentialClaimsSetBuilder timeToLive(long ttl, ChronoUnit ttlUnit) {
+        this.ttlUnit = Objects.requireNonNull(ttlUnit, "ttlUnit must not be null");
+        if (ttl < 1L) {
+            throw new IllegalArgumentException("ttl must be greater than zero");
+        }
+        this.ttl = ttl;
+        return this;
+    }
+
+    public VerifiableCredentialClaimsSetBuilder verifiableCredentialType(String type) {
+        if (StringUtils.isBlank(type)) {
+            throw new IllegalArgumentException(
+                    "The verifiable credential type must not be null or empty.");
+        }
+        this.verifiableCredentialType = type;
+        return this;
+    }
+
+    public VerifiableCredentialClaimsSetBuilder verifiableCredentialSubject(Object subject) {
+        this.verifiableCredentialSubject =
+                Objects.requireNonNull(subject, "subject must not be null");
+        return this;
+    }
+
+    public VerifiableCredentialClaimsSetBuilder verifiableCredentialContext(String[] contexts) {
+        this.contexts = Objects.requireNonNull(contexts, "contexts must not be null");
+        return this;
+    }
+
+    public VerifiableCredentialClaimsSetBuilder verifiableCredentialEvidence(Object evidence) {
+        this.evidence = Objects.requireNonNull(evidence, "evidence must not be null");
+        return this;
+    }
+
+    public JWTClaimsSet build() {
+        if (StringUtils.isBlank(this.verifiableCredentialType)) {
+            throw new IllegalStateException("The verifiable credential type must be specified");
+        }
+        if (StringUtils.isBlank(this.subject)) {
+            throw new IllegalStateException("The subject must be specified");
+        }
+        if (Objects.isNull(this.verifiableCredentialSubject)) {
+            throw new IllegalStateException("The verifiable credential subject must be specified");
+        }
+        String issuer = configurationService.getVerifiableCredentialIssuer();
+        if (StringUtils.isBlank(issuer)) {
+            throw new IllegalStateException(
+                    "An empty/null verifiable credential issuer was retrieved from configuration");
+        }
+        if (this.ttl < 1L) {
+            throw new IllegalStateException(
+                    "An invalid verifiable credential time-to-live was encountered");
+        }
+
+        OffsetDateTime dateTimeNow = OffsetDateTime.now(this.clock);
+        long expirationTimestamp = getExpirationTimestamp(dateTimeNow);
+
+        JWTClaimsSet.Builder builder =
+                new JWTClaimsSet.Builder()
+                        .subject(this.subject)
+                        .issuer(issuer)
+                        .claim(JWTClaimNames.NOT_BEFORE, dateTimeNow.toEpochSecond())
+                        .claim(JWTClaimNames.EXPIRATION_TIME, expirationTimestamp);
+
+        Map<String, Object> verifiableCredentialClaims = new LinkedHashMap<>();
+        verifiableCredentialClaims.put(
+                "type", new String[] {"VerifiableCredential", this.verifiableCredentialType});
+        if (Objects.nonNull(this.contexts) && contexts.length > 0) {
+            verifiableCredentialClaims.put("@context", contexts);
+        }
+        verifiableCredentialClaims.put("credentialSubject", verifiableCredentialSubject);
+        if (Objects.nonNull(evidence)) {
+            verifiableCredentialClaims.put("evidence", evidence);
+        }
+
+        builder.claim("vc", verifiableCredentialClaims);
+
+        return builder.build();
+    }
+
+    private long getExpirationTimestamp(OffsetDateTime dateTimeNow) {
+        switch (this.ttlUnit) {
+            case SECONDS:
+                return dateTimeNow.plusSeconds(this.ttl).toEpochSecond();
+            case MINUTES:
+                return dateTimeNow.plusMinutes(this.ttl).toEpochSecond();
+            case HOURS:
+                return dateTimeNow.plusHours(this.ttl).toEpochSecond();
+            case DAYS:
+                return dateTimeNow.plusDays(this.ttl).toEpochSecond();
+            case MONTHS:
+                return dateTimeNow.plusMonths(this.ttl).toEpochSecond();
+            case YEARS:
+                return dateTimeNow.plusYears(this.ttl).toEpochSecond();
+            default:
+                throw new IllegalStateException(
+                        "Unexpected time-to-live unit encountered: " + ttlUnit);
+        }
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilderTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilderTest.java
@@ -1,0 +1,275 @@
+package uk.gov.di.ipv.cri.common.library.util;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
+
+import java.text.ParseException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.nimbusds.jwt.JWTClaimNames.EXPIRATION_TIME;
+import static com.nimbusds.jwt.JWTClaimNames.NOT_BEFORE;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class VerifiableCredentialClaimsSetBuilderTest {
+    private static final String TEST_SUBJECT = UUID.randomUUID().toString();
+    private static final String TEST_ISSUER = "kbv-issuer";
+    private static final String TEST_VC_TYPE = "IdentityCheckCredential";
+    private static final PersonIdentityDetailed TEST_PERSON_IDENTITY =
+            mock(PersonIdentityDetailed.class);
+
+    @Mock private ConfigurationService mockConfigurationService;
+    private Clock clock;
+    private VerifiableCredentialClaimsSetBuilder builder;
+
+    @BeforeEach
+    void setup() {
+        this.clock = Clock.fixed(Instant.parse("2016-11-03T10:15:30Z"), ZoneId.of("UTC"));
+        this.builder = new VerifiableCredentialClaimsSetBuilder(mockConfigurationService, clock);
+    }
+
+    @Test
+    void shouldBuildVerifiableCredential() throws ParseException {
+        String[] testContexts = new String[] {"context1", "context2"};
+        Map<String, String> evidence =
+                Map.of(
+                        "evidence-key-1", "evidence-value-1",
+                        "evidence-key-2", "evidence-value-2");
+
+        initMockConfigurationService();
+
+        JWTClaimsSet builtClaimSet =
+                this.builder
+                        .subject(TEST_SUBJECT)
+                        .timeToLive(6L, ChronoUnit.MONTHS)
+                        .verifiableCredentialType(TEST_VC_TYPE)
+                        .verifiableCredentialSubject(TEST_PERSON_IDENTITY)
+                        .verifiableCredentialContext(testContexts)
+                        .verifiableCredentialEvidence(evidence)
+                        .build();
+
+        makeCommonClaimSetAssertions(builtClaimSet);
+        assertEquals(testContexts, builtClaimSet.getJSONObjectClaim("vc").get("@context"));
+        assertEquals(evidence, builtClaimSet.getJSONObjectClaim("vc").get("evidence"));
+    }
+
+    @Test
+    void shouldBuildVerifiableCredentialWithoutContextAndEvidence() throws ParseException {
+        initMockConfigurationService();
+
+        JWTClaimsSet builtClaimSet =
+                this.builder
+                        .subject(TEST_SUBJECT)
+                        .timeToLive(1L, ChronoUnit.MONTHS)
+                        .verifiableCredentialType(TEST_VC_TYPE)
+                        .verifiableCredentialSubject(TEST_PERSON_IDENTITY)
+                        .build();
+
+        makeCommonClaimSetAssertions(builtClaimSet);
+
+        assertNull(builtClaimSet.getJSONObjectClaim("vc").get("@context"));
+        assertNull(builtClaimSet.getJSONObjectClaim("vc").get("evidence"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "66,SECONDS,2016-11-03T10:16:36Z",
+        "30,MINUTES,2016-11-03T10:45:30Z",
+        "4,HOURS,2016-11-03T14:15:30Z",
+        "2,DAYS,2016-11-05T10:15:30Z",
+        "1,MONTHS,2016-12-03T10:15:30Z",
+        "2,YEARS,2018-11-03T10:15:30Z"
+    })
+    void shouldBuildVerifiableCredentialWithAppropriateExpirationTime(
+            long ttl, ChronoUnit ttlUnit, String expectedExpirationTime) throws ParseException {
+        initMockConfigurationService();
+
+        JWTClaimsSet builtClaimSet =
+                this.builder
+                        .subject(TEST_SUBJECT)
+                        .timeToLive(ttl, ttlUnit)
+                        .verifiableCredentialType(TEST_VC_TYPE)
+                        .verifiableCredentialSubject(TEST_PERSON_IDENTITY)
+                        .build();
+
+        assertEquals(
+                builtClaimSet.getLongClaim(EXPIRATION_TIME),
+                Instant.parse(expectedExpirationTime).getEpochSecond());
+    }
+
+    @Test
+    void shouldThrowErrorWhenVerifiableCredentialTypeNotSet() {
+        IllegalStateException thrownException =
+                assertThrows(IllegalStateException.class, () -> this.builder.build());
+        assertEquals(
+                "The verifiable credential type must be specified", thrownException.getMessage());
+    }
+
+    @Test
+    void shouldThrowErrorWhenSubjectNotSet() {
+        this.builder.verifiableCredentialType("IdentityCheckCredential");
+        IllegalStateException thrownException =
+                assertThrows(IllegalStateException.class, () -> this.builder.build());
+        assertEquals("The subject must be specified", thrownException.getMessage());
+    }
+
+    @Test
+    void shouldThrowErrorWhenVerifiableCredentialSubjectNotSet() {
+        this.builder.verifiableCredentialType("IdentityCheckCredential").subject("test-subject");
+        IllegalStateException thrownException =
+                assertThrows(IllegalStateException.class, () -> this.builder.build());
+        assertEquals(
+                "The verifiable credential subject must be specified",
+                thrownException.getMessage());
+    }
+
+    @Test
+    void shouldThrowErrorWhenIssuerNotSet() {
+        when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn("");
+
+        this.builder
+                .verifiableCredentialType("IdentityCheckCredential")
+                .verifiableCredentialSubject(mock(PersonIdentityDetailed.class))
+                .subject("test-subject");
+
+        IllegalStateException thrownException =
+                assertThrows(IllegalStateException.class, () -> this.builder.build());
+        assertEquals(
+                "An empty/null verifiable credential issuer was retrieved from configuration",
+                thrownException.getMessage());
+    }
+
+    @Test
+    void shouldThrowErrorWhenJwtTtlNotSet() {
+        when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn("issuer");
+        this.builder
+                .verifiableCredentialType("IdentityCheckCredential")
+                .verifiableCredentialSubject(mock(PersonIdentityDetailed.class))
+                .subject("test-subject");
+
+        IllegalStateException thrownException =
+                assertThrows(IllegalStateException.class, () -> this.builder.build());
+        assertEquals(
+                "An invalid verifiable credential time-to-live was encountered",
+                thrownException.getMessage());
+    }
+
+    @Test
+    void shouldThrowErrorWhenInvalidTtlSupplied() {
+        IllegalArgumentException thrownException =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> this.builder.timeToLive(0L, ChronoUnit.DAYS));
+        assertEquals("ttl must be greater than zero", thrownException.getMessage());
+    }
+
+    @Test
+    void shouldThrowErrorWhenInvalidTtlUnitSupplied() {
+        NullPointerException thrownException =
+                assertThrows(NullPointerException.class, () -> this.builder.timeToLive(1L, null));
+        assertEquals("ttlUnit must not be null", thrownException.getMessage());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldThrowErrorWhenInvalidSubjectSupplied(String testSubject) {
+        IllegalArgumentException thrownException =
+                assertThrows(
+                        IllegalArgumentException.class, () -> this.builder.subject(testSubject));
+        assertEquals("The subject must not be null or empty.", thrownException.getMessage());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldThrowErrorWhenInvalidTypeSupplied(String testVerifiableCredential) {
+        IllegalArgumentException thrownException =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> this.builder.verifiableCredentialType(testVerifiableCredential));
+        assertEquals(
+                "The verifiable credential type must not be null or empty.",
+                thrownException.getMessage());
+    }
+
+    @Test
+    void shouldThrowErrorWhenNullVerifiableCredentialSubjectSupplied() {
+        NullPointerException thrownException =
+                assertThrows(
+                        NullPointerException.class,
+                        () -> this.builder.verifiableCredentialSubject(null));
+        assertEquals("subject must not be null", thrownException.getMessage());
+    }
+
+    @Test
+    void shouldThrowErrorWhenNullVerifiableCredentialContextSupplied() {
+        NullPointerException thrownException =
+                assertThrows(
+                        NullPointerException.class,
+                        () -> this.builder.verifiableCredentialContext(null));
+        assertEquals("contexts must not be null", thrownException.getMessage());
+    }
+
+    @Test
+    void shouldThrowErrorWhenNullVerifiableCredentialEvidenceSupplied() {
+        NullPointerException thrownException =
+                assertThrows(
+                        NullPointerException.class,
+                        () -> this.builder.verifiableCredentialEvidence(null));
+        assertEquals("evidence must not be null", thrownException.getMessage());
+    }
+
+    @Test
+    void shouldThrowErrorWhenInvalidTimeToLiveUnitSupplied() {
+        initMockConfigurationService();
+        this.builder
+                .subject(TEST_SUBJECT)
+                .timeToLive(5L, ChronoUnit.MILLIS)
+                .verifiableCredentialType(TEST_VC_TYPE)
+                .verifiableCredentialSubject(TEST_PERSON_IDENTITY);
+        IllegalStateException thrownException =
+                assertThrows(IllegalStateException.class, () -> this.builder.build());
+        assertEquals(
+                "Unexpected time-to-live unit encountered: Millis", thrownException.getMessage());
+    }
+
+    private void makeCommonClaimSetAssertions(JWTClaimsSet builtClaimSet) throws ParseException {
+        assertNotNull(builtClaimSet);
+        assertEquals(TEST_SUBJECT, builtClaimSet.getSubject());
+        assertEquals(TEST_ISSUER, builtClaimSet.getIssuer());
+        assertEquals(this.clock.instant().getEpochSecond(), builtClaimSet.getLongClaim(NOT_BEFORE));
+        assertTrue(
+                builtClaimSet.getLongClaim(EXPIRATION_TIME)
+                        > this.clock.instant().getEpochSecond());
+        assertEquals(
+                TEST_PERSON_IDENTITY,
+                builtClaimSet.getJSONObjectClaim("vc").get("credentialSubject"));
+        assertArrayEquals(
+                new String[] {"VerifiableCredential", TEST_VC_TYPE},
+                (String[]) builtClaimSet.getJSONObjectClaim("vc").get("type"));
+    }
+
+    private void initMockConfigurationService() {
+        when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(TEST_ISSUER);
+    }
+}


### PR DESCRIPTION
### What changed
- Added `VerifiableCredentialClaimsSetBuilder` class

### Why did it change
- To centralise the creation of the verifiable credential JWT claims

### Issue tracking
- [OJ-976](https://govukverify.atlassian.net/browse/OJ-976)
