### PR TITLE
OJ-993 - Provide mechanism to add field(s) to logging context

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 1.3.0
+
+* Added method to persistently log specified key/value data when a log entry is written 
+
 ## 1.2.0
 
 * Added VerifiableCredentialClaimsSetBuilder class to centralise the creation of the verifiable credential JWT claims set

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "1.2.0"
+def buildVersion = "1.3.0"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/EventProbe.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/EventProbe.java
@@ -1,19 +1,21 @@
 package uk.gov.di.ipv.cri.common.library.util;
 
+import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
+import software.amazon.lambda.powertools.logging.LoggingUtils;
 import software.amazon.lambda.powertools.metrics.MetricsUtils;
 
 import java.util.Map;
 import java.util.Objects;
 
 public class EventProbe {
-
+    private static final String GOVUK_SIGNIN_JOURNEY_ID = "govuk_signin_journey_id";
     private static final Logger LOGGER = LogManager.getLogger();
-    private static final MetricsLogger metricsLogger = MetricsUtils.metricsLogger();
+    private static final MetricsLogger METRICS_LOGGER = MetricsUtils.metricsLogger();
 
     public EventProbe log(Level level, Throwable throwable) {
         LOGGER.log(level, throwable.getMessage(), throwable);
@@ -39,12 +41,12 @@ public class EventProbe {
     }
 
     public EventProbe counterMetric(String key) {
-        metricsLogger.putMetric(key, 1d);
+        METRICS_LOGGER.putMetric(key, 1d);
         return this;
     }
 
     public EventProbe counterMetric(String key, double value) {
-        metricsLogger.putMetric(key, value);
+        METRICS_LOGGER.putMetric(key, value);
         return this;
     }
 
@@ -53,11 +55,23 @@ public class EventProbe {
         return this;
     }
 
+    public EventProbe addFieldToLoggingContext(String name, String value) {
+        LoggingUtils.appendKey(name, value);
+        return this;
+    }
+
+    public EventProbe addJourneyIdToLoggingContext(String journeyId) {
+        if (StringUtils.isNotBlank(journeyId)) {
+            addFieldToLoggingContext(GOVUK_SIGNIN_JOURNEY_ID, journeyId);
+        }
+        return this;
+    }
+
     public void addDimensions(Map<String, String> dimensions) {
         if (dimensions != null) {
             DimensionSet dimensionSet = new DimensionSet();
             dimensions.forEach(dimensionSet::addDimension);
-            metricsLogger.putDimensions(dimensionSet);
+            METRICS_LOGGER.putDimensions(dimensionSet);
         }
     }
 }


### PR DESCRIPTION
### What changed
- Added new method to the `EventProbe` class to add a field to the logging context

### Why did it change
- To enable the journey id to be recorded against log entries

### Issue tracking
- [OJ-993](https://govukverify.atlassian.net/browse/OJ-993)
