### PR TITLE
LIME-173 add END AuditEventType to enable sending CRI_END audit event.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 1.3.1
+
+* Added `END` AuditEventType to enable sending `CRI_END` audit event
+
 ## 1.3.0
 
 * Added method to persistently log specified key/value data when a log entry is written 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "1.3.0"
+def buildVersion = "1.3.1"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEventType.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEventType.java
@@ -6,4 +6,5 @@ public enum AuditEventType {
     REQUEST_SENT, // When a third party call is started
     VC_ISSUED, // When the final VC is created in the issue credential lambda
     THIRD_PARTY_REQUEST_ENDED, // When a third party requests are ended
+    END, // When VC credentials are being returned - final event
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Added End AuditEventType.

### Why did it change

To enable sending CRI_END audit event.
Generated identically to CRI_START but using the END AuditEventType vs START.

### Issue tracking

- [LIME-173](https://govukverify.atlassian.net/browse/LIME-173)