### PR TITLE
OJ-1075 - Integration testing - Add common clients and cucumber steps

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 1.4.0
+
+* Added common clients/steps for cucumber integration-testing
+
 ## 1.3.1
 
 * Added `END` AuditEventType to enable sending `CRI_END` audit event

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,16 @@
 plugins {
-	id "java"
+	id "java-library"
+	id "java-test-fixtures"
 	id "org.sonarqube"
 	id "com.diffplug.spotless"
 	id "jacoco"
+	id "maven-publish"
+	id "signing"
 	id "io.github.gradle-nexus.publish-plugin" version "1.0.0"
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "1.3.1"
+def buildVersion = "1.4.0"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 
@@ -18,10 +21,10 @@ ext {
 		aws_powertools_version   : "1.12.0",
 		nimbusds_oauth_version   : "9.25",
 		nimbusds_jwt_version     : "9.15.1",
-		protobuf_version         : "3.19.4",
 		junit                    : "5.8.2",
 		mockito					 : "4.3.1",
-		glassfish_version        : "3.0.3"
+		glassfish_version        : "3.0.3",
+		cucumber_version         : "7.9.0"
 	]
 }
 
@@ -55,6 +58,7 @@ configurations {
 	gson
 	powertools
 	mockito
+	cucumber
 }
 
 // The dynamodb enhanced package loads the apache-client as well as the spi-client, so
@@ -102,6 +106,9 @@ dependencies {
 			"uk.org.webcompere:system-stubs-core:2.0.1"
 
 	test_runtime "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit}"
+
+	cucumber "io.cucumber:cucumber-java:${dependencyVersions.cucumber_version}",
+			"io.cucumber:cucumber-picocontainer:${dependencyVersions.cucumber_version}"
 }
 
 dependencies {
@@ -118,6 +125,10 @@ dependencies {
 	testImplementation configurations.tests
 
 	testRuntimeOnly configurations.test_runtime
+
+	testFixturesApi	configurations.cucumber
+	testFixturesImplementation configurations.jackson
+	testFixturesImplementation configurations.tests
 }
 
 tasks.named("jar") {
@@ -137,9 +148,6 @@ jacocoTestReport {
 		xml.required.set(true)
 	}
 }
-
-apply plugin: 'java'
-
 
 sonarqube {
 	properties {
@@ -174,11 +182,6 @@ gradle.projectsEvaluated {
 		options.compilerArgs << "-Xlint:unchecked"
 	}
 }
-
-apply plugin: 'java-library'
-apply plugin: 'maven-publish'
-apply plugin: 'signing'
-apply plugin: 'io.github.gradle-nexus.publish-plugin'
 
 group = "uk.gov.account"
 version = "$buildVersion"
@@ -233,6 +236,18 @@ publishing {
 				developers {
 					developer {
 						name = 'GDS Developers'
+					}
+				}
+			}
+			// The java-test-fixtures plugin results in the API dependencies for testFixtures
+			// being added to the pom with <scope>compile</scope> & <optional>true</optional>.
+			// This is not desired as the scope is incorrect and the testFixtures are referenced
+			// via gradle module metadata. The code below removes the unwanted optional dependencies
+			// from the pom.
+			pom.withXml {
+				asNode().dependencies.dependency.each { dep ->
+					if(dep.optional.text() == 'true') {
+						dep.parent().remove(dep)
 					}
 				}
 			}

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,4 +4,4 @@ pluginManagement {
 		id "com.diffplug.spotless" version "6.1.0"
 	}
 }
-rootProject.name = "di-ipv-cri-common-library"
+rootProject.name = "cri-common-lib"

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/ClientConfigurationService.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/ClientConfigurationService.java
@@ -1,0 +1,99 @@
+package uk.gov.di.ipv.cri.common.library.client;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class ClientConfigurationService {
+    private static final String MISSING_ENV_VARIABLE_ERROR_MSG_FORMAT =
+            "Environment variable %s is not set";
+    private final String environment;
+    private final String privateApiEndpoint;
+    private final String publicApiEndpoint;
+    private final String publicApiKey;
+    private final String ipvCoreStubUrl;
+    private final String ipvCoreStubUsername;
+    private final String ipvCoreStubPassword;
+    private final String ipvCoreStubCriId;
+
+    public ClientConfigurationService() {
+        this.environment =
+                Objects.requireNonNull(
+                        System.getenv("ENVIRONMENT"),
+                        String.format(MISSING_ENV_VARIABLE_ERROR_MSG_FORMAT, "ENVIRONMENT"));
+        this.privateApiEndpoint =
+                getApiEndpoint(
+                        "API_GATEWAY_ID_PRIVATE",
+                        String.format(
+                                MISSING_ENV_VARIABLE_ERROR_MSG_FORMAT, "API_GATEWAY_ID_PRIVATE"));
+        this.publicApiEndpoint =
+                getApiEndpoint(
+                        "API_GATEWAY_ID_PUBLIC",
+                        String.format(
+                                MISSING_ENV_VARIABLE_ERROR_MSG_FORMAT, "API_GATEWAY_ID_PUBLIC"));
+        this.publicApiKey =
+                Objects.requireNonNull(
+                        System.getenv("APIGW_API_KEY"),
+                        String.format(MISSING_ENV_VARIABLE_ERROR_MSG_FORMAT, "APIGW_API_KEY"));
+        this.ipvCoreStubUrl =
+                Objects.requireNonNull(
+                        System.getenv("IPV_CORE_STUB_URL"),
+                        String.format(MISSING_ENV_VARIABLE_ERROR_MSG_FORMAT, "IPV_CORE_STUB_URL"));
+        this.ipvCoreStubUsername =
+                Objects.requireNonNull(
+                        System.getenv("IPV_CORE_STUB_BASIC_AUTH_USER"),
+                        String.format(
+                                MISSING_ENV_VARIABLE_ERROR_MSG_FORMAT,
+                                "IPV_CORE_STUB_BASIC_AUTH_USER"));
+        this.ipvCoreStubPassword =
+                Objects.requireNonNull(
+                        System.getenv("IPV_CORE_STUB_BASIC_AUTH_PASSWORD"),
+                        String.format(
+                                MISSING_ENV_VARIABLE_ERROR_MSG_FORMAT,
+                                "IPV_CORE_STUB_BASIC_AUTH_PASSWORD"));
+        this.ipvCoreStubCriId =
+                Objects.requireNonNull(
+                        System.getenv("IPV_CORE_STUB_CRI_ID"),
+                        String.format(
+                                MISSING_ENV_VARIABLE_ERROR_MSG_FORMAT, "IPV_CORE_STUB_CRI_ID"));
+    }
+
+    public String getPrivateApiEndpoint() {
+        return this.privateApiEndpoint;
+    }
+
+    public String getPublicApiEndpoint() {
+        return this.publicApiEndpoint;
+    }
+
+    public String getPublicApiKey() {
+        return this.publicApiKey;
+    }
+
+    public String getIPVCoreStubURL() {
+        return this.ipvCoreStubUrl;
+    }
+
+    public String getIpvCoreStubUsername() {
+        return this.ipvCoreStubUsername;
+    }
+
+    public String getIpvCoreStubPassword() {
+        return this.ipvCoreStubPassword;
+    }
+
+    public String getIpvCoreStubCriId() {
+        return ipvCoreStubCriId;
+    }
+
+    public String createUriPath(String endpoint) {
+        return String.format("/%s/%s", this.environment, endpoint);
+    }
+
+    private static String getApiEndpoint(String apikey, String message) {
+        String restApiId =
+                Optional.ofNullable(System.getenv(apikey))
+                        .orElseThrow(() -> new IllegalArgumentException(message));
+
+        return String.format("https://%s.execute-api.eu-west-2.amazonaws.com", restApiId);
+    }
+}

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/CommonApiClient.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/CommonApiClient.java
@@ -1,0 +1,94 @@
+package uk.gov.di.ipv.cri.common.library.client;
+
+import uk.gov.di.ipv.cri.common.library.util.URIBuilder;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public class CommonApiClient {
+
+    private final HttpClient httpClient;
+    private final ClientConfigurationService clientConfigurationService;
+
+    public CommonApiClient(ClientConfigurationService clientConfigurationService) {
+        this.clientConfigurationService = clientConfigurationService;
+        this.httpClient = HttpClient.newBuilder().build();
+    }
+
+    private static final String JSON_MIME_MEDIA_TYPE = "application/json";
+
+    public HttpResponse<String> sendAuthorizationRequest(String sessionId)
+            throws IOException, InterruptedException {
+        var url =
+                new URIBuilder(this.clientConfigurationService.getPrivateApiEndpoint())
+                        .setPath(this.clientConfigurationService.createUriPath("authorization"))
+                        .addParameter(
+                                "redirect_uri",
+                                new URIBuilder(this.clientConfigurationService.getIPVCoreStubURL())
+                                        .setPath("/callback")
+                                        .build()
+                                        .toString())
+                        .addParameter("client_id", "ipv-core-stub")
+                        .addParameter("response_type", "code")
+                        .addParameter("scope", "openid")
+                        .addParameter("state", "state-ipv")
+                        .build();
+
+        var request =
+                HttpRequest.newBuilder()
+                        .uri(url)
+                        .header(HttpHeaders.ACCEPT, JSON_MIME_MEDIA_TYPE)
+                        .header(HttpHeaders.SESSION_ID, sessionId)
+                        .GET()
+                        .build();
+        return sendHttpRequest(request);
+    }
+
+    public HttpResponse<String> sendSessionRequest(String sessionRequestBody)
+            throws IOException, InterruptedException {
+        var request =
+                HttpRequest.newBuilder()
+                        .uri(
+                                new URIBuilder(
+                                                this.clientConfigurationService
+                                                        .getPrivateApiEndpoint())
+                                        .setPath(
+                                                this.clientConfigurationService.createUriPath(
+                                                        "session"))
+                                        .build())
+                        .header(HttpHeaders.ACCEPT, JSON_MIME_MEDIA_TYPE)
+                        .header(HttpHeaders.CONTENT_TYPE, JSON_MIME_MEDIA_TYPE)
+                        .header("X-Forwarded-For", "192.168.0.1")
+                        .POST(HttpRequest.BodyPublishers.ofString(sessionRequestBody))
+                        .build();
+        return sendHttpRequest(request);
+    }
+
+    public HttpResponse<String> sendTokenRequest(String privateKeyJwt)
+            throws IOException, InterruptedException {
+        var request =
+                HttpRequest.newBuilder()
+                        .uri(
+                                new URIBuilder(
+                                                this.clientConfigurationService
+                                                        .getPublicApiEndpoint())
+                                        .setPath(
+                                                this.clientConfigurationService.createUriPath(
+                                                        "token"))
+                                        .build())
+                        .header(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded")
+                        .header(
+                                HttpHeaders.API_KEY,
+                                this.clientConfigurationService.getPublicApiKey())
+                        .POST(HttpRequest.BodyPublishers.ofString(privateKeyJwt))
+                        .build();
+        return sendHttpRequest(request);
+    }
+
+    private HttpResponse<String> sendHttpRequest(HttpRequest request)
+            throws IOException, InterruptedException {
+        return this.httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+}

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/HttpHeaders.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/HttpHeaders.java
@@ -1,0 +1,12 @@
+package uk.gov.di.ipv.cri.common.library.client;
+
+public final class HttpHeaders {
+    private HttpHeaders() {
+        // do not allow instantiation
+    }
+
+    public static final String ACCEPT = "Accept";
+    public static final String CONTENT_TYPE = "Content-Type";
+    public static final String SESSION_ID = "session-id";
+    public static final String API_KEY = "x-api-key"; // pragma: allowlist secret
+}

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/IpvCoreStubClient.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/IpvCoreStubClient.java
@@ -1,0 +1,86 @@
+package uk.gov.di.ipv.cri.common.library.client;
+
+import uk.gov.di.ipv.cri.common.library.util.URIBuilder;
+
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public class IpvCoreStubClient {
+    private static final String JSON_MIME_MEDIA_TYPE = "application/json";
+
+    private final HttpClient httpClient;
+    private final ClientConfigurationService clientConfigurationService;
+
+    public IpvCoreStubClient(ClientConfigurationService clientConfigurationService) {
+        this.clientConfigurationService = clientConfigurationService;
+
+        this.httpClient =
+                HttpClient.newBuilder()
+                        .authenticator(
+                                new Authenticator() {
+                                    @Override
+                                    protected PasswordAuthentication getPasswordAuthentication() {
+                                        return new PasswordAuthentication(
+                                                clientConfigurationService.getIpvCoreStubUsername(),
+                                                clientConfigurationService
+                                                        .getIpvCoreStubPassword()
+                                                        .toCharArray());
+                                    }
+                                })
+                        .build();
+    }
+
+    public String getClaimsForUser(int userDataRowNumber) throws IOException, InterruptedException {
+        URI uri =
+                new URIBuilder(this.clientConfigurationService.getIPVCoreStubURL())
+                        .setPath("/backend/generateInitialClaimsSet")
+                        .addParameter("cri", clientConfigurationService.getIpvCoreStubCriId())
+                        .addParameter("rowNumber", String.valueOf(userDataRowNumber))
+                        .build();
+        HttpRequest request = HttpRequest.newBuilder().uri(uri).GET().build();
+        return sendHttpRequest(request).body();
+    }
+
+    public String createSessionRequest(String requestBody)
+            throws IOException, InterruptedException {
+
+        var uri =
+                new URIBuilder(this.clientConfigurationService.getIPVCoreStubURL())
+                        .setPath("/backend/createSessionRequest")
+                        .addParameter("cri", clientConfigurationService.getIpvCoreStubCriId())
+                        .build();
+
+        HttpRequest request =
+                HttpRequest.newBuilder()
+                        .uri(uri)
+                        .header(HttpHeaders.ACCEPT, JSON_MIME_MEDIA_TYPE)
+                        .header(HttpHeaders.CONTENT_TYPE, JSON_MIME_MEDIA_TYPE)
+                        .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                        .build();
+
+        return sendHttpRequest(request).body();
+    }
+
+    public String getPrivateKeyJWTFormParamsForAuthCode(String authorizationCode)
+            throws IOException, InterruptedException {
+        var url =
+                new URIBuilder(this.clientConfigurationService.getIPVCoreStubURL())
+                        .setPath("/backend/createTokenRequestPrivateKeyJWT")
+                        .addParameter("cri", clientConfigurationService.getIpvCoreStubCriId())
+                        .addParameter("authorization_code", authorizationCode)
+                        .build();
+
+        HttpRequest request = HttpRequest.newBuilder().uri(url).GET().build();
+        return sendHttpRequest(request).body();
+    }
+
+    private HttpResponse<String> sendHttpRequest(HttpRequest request)
+            throws IOException, InterruptedException {
+        return this.httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+}

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/CommonSteps.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/CommonSteps.java
@@ -1,0 +1,100 @@
+package uk.gov.di.ipv.cri.common.library.stepdefinitions;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import uk.gov.di.ipv.cri.common.library.client.ClientConfigurationService;
+import uk.gov.di.ipv.cri.common.library.client.CommonApiClient;
+import uk.gov.di.ipv.cri.common.library.client.IpvCoreStubClient;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class CommonSteps {
+    private final ObjectMapper objectMapper;
+    private final CommonApiClient commonApiClient;
+    private final IpvCoreStubClient ipvCoreStubClient;
+    private final CriTestContext testContext;
+
+    private String sessionRequestBody;
+    private String authorizationCode;
+
+    public CommonSteps(
+            ClientConfigurationService clientConfigurationService, CriTestContext testContext) {
+        this.commonApiClient = new CommonApiClient(clientConfigurationService);
+        this.ipvCoreStubClient = new IpvCoreStubClient(clientConfigurationService);
+        this.objectMapper = new ObjectMapper();
+        this.testContext = testContext;
+    }
+
+    @Given("user has the test-identity {int} in the form of a signed JWT string")
+    public void userHasTheTestIdentityInTheFormOfASignedJWTString(int testUserDataSheetRowNumber)
+            throws IOException, InterruptedException {
+        this.testContext.setSerialisedUserIdentity(
+                this.ipvCoreStubClient.getClaimsForUser(testUserDataSheetRowNumber));
+        sessionRequestBody =
+                this.ipvCoreStubClient.createSessionRequest(
+                        this.testContext.getSerialisedUserIdentity());
+    }
+
+    @When("user sends a POST request to session end point")
+    public void userSendsAPostRequestToSessionEndpoint() throws IOException, InterruptedException {
+
+        this.testContext.setResponse(this.commonApiClient.sendSessionRequest(sessionRequestBody));
+        Map<String, String> deserializedResponse =
+                objectMapper.readValue(
+                        this.testContext.getResponse().body(), new TypeReference<>() {});
+        this.testContext.setSessionId(deserializedResponse.get("session_id"));
+    }
+
+    @When("user sends a GET request to authorization end point")
+    public void userSendsAGetRequestToAuthorizationEndpoint()
+            throws IOException, InterruptedException {
+        this.testContext.setResponse(
+                this.commonApiClient.sendAuthorizationRequest(this.testContext.getSessionId()));
+    }
+
+    @When("user sends a POST request to token end point")
+    public void userSendsAPostRequestToTokenEndpoint() throws IOException, InterruptedException {
+        String privateKeyJWT =
+                this.ipvCoreStubClient.getPrivateKeyJWTFormParamsForAuthCode(
+                        authorizationCode.trim());
+        this.testContext.setResponse(this.commonApiClient.sendTokenRequest(privateKeyJWT));
+    }
+
+    @Then("user gets a session-id")
+    public void userGetsASessionId() {
+        assertNotNull(this.testContext.getSessionId());
+    }
+
+    @Then("user gets status code {int}")
+    public void userGetsStatusCode(int statusCode) {
+        assertEquals(statusCode, this.testContext.getResponse().statusCode());
+    }
+
+    @And("a valid authorization code is returned in the response")
+    public void aValidAuthorizationCodeIsReturnedInTheResponse() throws IOException {
+        JsonNode jsonNode = objectMapper.readTree(this.testContext.getResponse().body());
+        authorizationCode = jsonNode.get("authorizationCode").get("value").textValue();
+        assertNotNull(authorizationCode);
+    }
+
+    @And("a valid access token code is returned in the response")
+    public void aValidAccessTokenCodeIsReturnedInTheResponse() throws IOException {
+        JsonNode jsonNode = objectMapper.readTree(this.testContext.getResponse().body());
+        this.testContext.setAccessToken(jsonNode.get("access_token").asText());
+        var expiresIn = jsonNode.get("expires_in").asInt();
+        var tokenType = jsonNode.get("token_type").asText();
+        assertEquals(3600, expiresIn);
+        assertEquals("Bearer", tokenType);
+        assertFalse(this.testContext.getAccessToken().isEmpty());
+    }
+}

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/CriTestContext.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/stepdefinitions/CriTestContext.java
@@ -1,0 +1,42 @@
+package uk.gov.di.ipv.cri.common.library.stepdefinitions;
+
+import java.net.http.HttpResponse;
+
+public class CriTestContext {
+    private HttpResponse<String> response;
+    private String sessionId;
+    private String accessToken;
+    private String serialisedUserIdentity;
+
+    public HttpResponse<String> getResponse() {
+        return response;
+    }
+
+    public void setResponse(HttpResponse<String> response) {
+        this.response = response;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getSerialisedUserIdentity() {
+        return serialisedUserIdentity;
+    }
+
+    public void setSerialisedUserIdentity(String serialisedUserIdentity) {
+        this.serialisedUserIdentity = serialisedUserIdentity;
+    }
+}

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/util/URIBuilder.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/util/URIBuilder.java
@@ -1,0 +1,64 @@
+package uk.gov.di.ipv.cri.common.library.util;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class URIBuilder {
+    private final Map<String, String> queryStringParameters;
+    private final String baseUri;
+    private String path;
+
+    public URIBuilder(String baseUri) {
+        if (isBlankOrEmpty(baseUri)) {
+            throw new IllegalArgumentException("baseUri must not be null or empty");
+        }
+        this.baseUri = baseUri.endsWith("/") ? baseUri.substring(0, baseUri.length() - 1) : baseUri;
+        this.queryStringParameters = new HashMap<>();
+    }
+
+    public URIBuilder setPath(String path) {
+        if (isBlankOrEmpty(path)) {
+            throw new IllegalArgumentException("path must not be null or empty");
+        }
+        this.path = path.startsWith("/") ? path : "/".concat(path);
+        return this;
+    }
+
+    public URIBuilder addParameter(String name, String value) {
+        if (isBlankOrEmpty(name)) {
+            throw new IllegalArgumentException("name must not be null or empty");
+        }
+        if (isBlankOrEmpty(value)) {
+            Objects.requireNonNull(value, "value must not be null or emtpy");
+        }
+        this.queryStringParameters.put(name, value);
+        return this;
+    }
+
+    public URI build() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.baseUri);
+        if (Objects.nonNull(this.path)) {
+            sb.append(this.path);
+        }
+        if (!this.queryStringParameters.isEmpty()) {
+            String[] queryStringParams =
+                    this.queryStringParameters.entrySet().stream()
+                            .map(
+                                    keyValue ->
+                                            String.format(
+                                                    "%s=%s",
+                                                    keyValue.getKey(), keyValue.getValue()))
+                            .toArray(String[]::new);
+            sb.append("?");
+            sb.append(String.join("&", queryStringParams));
+        }
+        return URI.create(sb.toString());
+    }
+
+    private boolean isBlankOrEmpty(String input) {
+        return Objects.isNull(input) || (input.isEmpty() || input.isBlank());
+    }
+}


### PR DESCRIPTION
### What changed
- Added test fixtures to provide the common lambdas/ipv-core-stub API clients and cucumbers steps
- Removed the inconsistent use of the plugins in `build.gradle`

### Why did it change
- To provide an initial framework for the CRI integration tests
- To remove the duplication of code present in the address/kbv cri integration tests modules
- Note, the majority of code introduced in this PR has come from the `kbv-api` repository

### Issue tracking
- [OJ-1075](https://govukverify.atlassian.net/browse/OJ-1075)
