### PR TITLE
OJ-1146 workflow deprecations and sam fix

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: zulu
@@ -28,11 +28,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: zulu
@@ -55,11 +55,11 @@ jobs:
       - build
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: zulu
@@ -99,12 +99,12 @@ jobs:
       - run-unit-tests
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
           submodules: true
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: zulu

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/Yelp/detect-secrets
-    rev: v1.3.0
+    rev: v1.4.0
     hooks:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.0",
+  "version": "1.4.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -19,6 +19,9 @@
     },
     {
       "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
     },
     {
       "name": "GitHubTokenDetector"
@@ -73,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -115,14 +114,14 @@
         "filename": "src/test/java/uk/gov/di/ipv/cri/common/library/service/AccessTokenServiceTest.java",
         "hashed_secret": "180e046dc228a5ea27fa4110378bd97ac0da05d1",
         "is_verified": false,
-        "line_number": 52
+        "line_number": 51
       },
       {
         "type": "JSON Web Token",
         "filename": "src/test/java/uk/gov/di/ipv/cri/common/library/service/AccessTokenServiceTest.java",
         "hashed_secret": "e55b323f50ded2181b3e185621f24d9977446a70",
         "is_verified": false,
-        "line_number": 55
+        "line_number": 59
       }
     ],
     "src/test/java/uk/gov/di/ipv/cri/common/library/service/ConfigurationServiceTest.java": [
@@ -154,35 +153,35 @@
         "filename": "src/test/java/uk/gov/di/ipv/cri/common/library/service/JWTVerifierTest.java",
         "hashed_secret": "d7a0aef78689a68004669b265210bd603e93fbfd",
         "is_verified": false,
-        "line_number": 42
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/test/java/uk/gov/di/ipv/cri/common/library/service/JWTVerifierTest.java",
-        "hashed_secret": "dc620e25f02856ddf327f15dd9d627b029e6e949",
-        "is_verified": false,
-        "line_number": 45
+        "line_number": 134
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/test/java/uk/gov/di/ipv/cri/common/library/service/JWTVerifierTest.java",
         "hashed_secret": "3bff7544b01bd034a3090decdbba1a2a67ccc078",
         "is_verified": false,
-        "line_number": 48
+        "line_number": 305
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/test/java/uk/gov/di/ipv/cri/common/library/service/JWTVerifierTest.java",
         "hashed_secret": "6a8c681d20885071789abdd0058fd0931924f31a",
         "is_verified": false,
-        "line_number": 51
+        "line_number": 319
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/java/uk/gov/di/ipv/cri/common/library/service/JWTVerifierTest.java",
+        "hashed_secret": "dc620e25f02856ddf327f15dd9d627b029e6e949",
+        "is_verified": false,
+        "line_number": 333
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/test/java/uk/gov/di/ipv/cri/common/library/service/JWTVerifierTest.java",
         "hashed_secret": "6867c9f889fe8fa27aa8accbf2e51a35bcb16e0d",
         "is_verified": false,
-        "line_number": 54
+        "line_number": 342
       }
     ],
     "src/test/java/uk/gov/di/ipv/cri/common/library/util/SignedJWTFactoryTest.java": [
@@ -209,5 +208,5 @@
       }
     ]
   },
-  "generated_at": "2022-09-23T07:44:12Z"
+  "generated_at": "2023-01-06T10:15:22Z"
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Address, Fraud and KBV SSM parameter deployment workflows have been updated:

* Deprecated GHA actions have been updated to the newer versions.
* setup-sam fix has been applied

### Why did it change

Primarily to apply the setup-sam fix so that the workflows are not broken.
(https://github.com/aws/aws-sam-cli/issues/4527)

Secondly in preparation for GitHub to remove the deprecated functionality.

### Issue tracking

- [OJ-1146](https://govukverify.atlassian.net/browse/OJ-1146)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-1146]: https://govukverify.atlassian.net/browse/OJ-1146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ