### PR TITLE
LIME-406 - Added RESPONSE_RECEIVED to the AuditEventType

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Credential Issuer common libraries Release Notes
 
+## 1.4.1
+
+* Added `RESPONSE_RECEIVED` to replace `THIRD_PARTY_REQUEST_ENDED` 
+* `THIRD_PARTY_REQUEST_ENDED` left for backward compatibility
+
 ## 1.4.0
 
 * Added common clients/steps for cucumber integration-testing

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "1.4.0"
+def buildVersion = "1.4.1"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEventType.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEventType.java
@@ -7,4 +7,5 @@ public enum AuditEventType {
     VC_ISSUED, // When the final VC is created in the issue credential lambda
     THIRD_PARTY_REQUEST_ENDED, // When a third party requests are ended
     END, // When VC credentials are being returned - final event
+    RESPONSE_RECEIVED, // This is to replace THIRD_PARTY_REQUEST_ENDED
 }


### PR DESCRIPTION
### What changed

Added RESPONSE_RECEIVED to the AuditEventType

### Why did it change

This is to replace THIRD_PARTY_REQUEST_ENDED

