### PR TITLE
LIME-440 - Capture Driving Licence issuer in TxMA Audit Events

### DIFF
--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/DrivingPermit.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/DrivingPermit.java
@@ -1,0 +1,55 @@
+package uk.gov.di.ipv.cri.common.library.domain.personidentity;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.LocalDate;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DrivingPermit {
+    private String personalNumber;
+    private LocalDate expiryDate;
+
+    private String issueNumber;
+    private DrivingPermitIssuer issuedBy;
+    private LocalDate issueDate;
+
+    public String getPersonalNumber() {
+        return personalNumber;
+    }
+
+    public void setPersonalNumber(String personalNumber) {
+        this.personalNumber = personalNumber;
+    }
+
+    public LocalDate getExpiryDate() {
+        return expiryDate;
+    }
+
+    public void setExpiryDate(LocalDate expiryDate) {
+        this.expiryDate = expiryDate;
+    }
+
+    public String getIssueNumber() {
+        return issueNumber;
+    }
+
+    public void setIssueNumber(String issueNumber) {
+        this.issueNumber = issueNumber;
+    }
+
+    public DrivingPermitIssuer getIssuedBy() {
+        return issuedBy;
+    }
+
+    public void setIssuedBy(DrivingPermitIssuer issuedBy) {
+        this.issuedBy = issuedBy;
+    }
+
+    public LocalDate getIssueDate() {
+        return issueDate;
+    }
+
+    public void setIssueDate(LocalDate issueDate) {
+        this.issueDate = issueDate;
+    }
+}

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/DrivingPermitIssuer.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/DrivingPermitIssuer.java
@@ -1,0 +1,6 @@
+package uk.gov.di.ipv.cri.common.library.domain.personidentity;
+
+public enum DrivingPermitIssuer {
+    DVA,
+    DVLA
+}

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/PersonIdentityDetailed.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/PersonIdentityDetailed.java
@@ -16,11 +16,18 @@ public class PersonIdentityDetailed {
     @JsonProperty("address")
     private final List<Address> addresses;
 
+    @JsonProperty("drivingPermit")
+    private final List<DrivingPermit> drivingPermits;
+
     public PersonIdentityDetailed(
-            List<Name> names, List<BirthDate> birthDates, List<Address> addresses) {
+            List<Name> names,
+            List<BirthDate> birthDates,
+            List<Address> addresses,
+            List<DrivingPermit> drivingPermits) {
         this.names = names;
         this.birthDates = birthDates;
         this.addresses = addresses;
+        this.drivingPermits = drivingPermits;
     }
 
     public List<Name> getNames() {
@@ -33,5 +40,9 @@ public class PersonIdentityDetailed {
 
     public List<Address> getAddresses() {
         return addresses;
+    }
+
+    public List<DrivingPermit> getDrivingPermits() {
+        return drivingPermits;
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapper.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapper.java
@@ -96,7 +96,7 @@ class PersonIdentityMapper {
             addresses = mapCanonicalAddresses(personIdentityItem.getAddresses());
         }
 
-        return new PersonIdentityDetailed(names, dobs, addresses);
+        return new PersonIdentityDetailed(names, dobs, addresses, null);
     }
 
     private List<Address> mapCanonicalAddresses(List<CanonicalAddress> addresses) {

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapperTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/service/PersonIdentityMapperTest.java
@@ -305,7 +305,8 @@ class PersonIdentityMapperTest {
         address.setValidFrom(TODAY);
 
         PersonIdentityDetailed testPersonIdentity =
-                new PersonIdentityDetailed(List.of(name), List.of(birthDate), List.of(address));
+                new PersonIdentityDetailed(
+                        List.of(name), List.of(birthDate), List.of(address), null);
 
         PersonIdentity mappedPersonIdentity =
                 this.personIdentityMapper.mapToPersonIdentity(testPersonIdentity);


### PR DESCRIPTION
## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- audit event support added for `drivingPermit` data

### Issue tracking

- [LIME-440](https://govukverify.atlassian.net/browse/LIME-440)

## Checklists

### Other considerations

Tests have yet to be created, similar changes might need to be made when support for `passport` data on a future ticket.