### PR TITLE
OJ-1305: Added code to redact sensitive fields

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Credential Issuer common libraries Release Notes
 
+## 1.4.3
+
+* Added `PiiRedactingDeserializer`
+
+
 ## 1.4.2
 
 * Added `DrivingPermit` and `DrivingPermitIssuer`

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "1.4.2"
+def buildVersion = "1.4.3"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/deserializers/PiiRedactingDeserializer.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/deserializers/PiiRedactingDeserializer.java
@@ -1,0 +1,142 @@
+package uk.gov.di.ipv.cri.common.library.util.deserializers;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerFactory;
+import com.fasterxml.jackson.databind.deser.ResolvableDeserializer;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TreeTraversingParser;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+public class PiiRedactingDeserializer<T> extends JsonDeserializer<T> {
+    private final List<String> sensitiveFields;
+    private final Class<T> clazz;
+    private final boolean allFieldsAreSensitiveOption;
+
+    public PiiRedactingDeserializer(Class<T> clazz) {
+        this(Collections.emptyList(), clazz);
+    }
+
+    public PiiRedactingDeserializer(List<String> sensitiveFields, Class<T> clazz) {
+        this(sensitiveFields, clazz, true);
+    }
+
+    public PiiRedactingDeserializer(
+            List<String> sensitiveFields, Class<T> clazz, boolean allFieldsAreSensitiveOption) {
+        this.sensitiveFields = sensitiveFields;
+        this.clazz = clazz;
+        this.allFieldsAreSensitiveOption = allFieldsAreSensitiveOption;
+    }
+
+    @SuppressWarnings("unchecked")
+    public T deserialize(JsonParser parser, DeserializationContext context)
+            throws IOException, NullPointerException {
+        JsonNode rootNode = null;
+        try {
+            ObjectMapper objectMapper = (ObjectMapper) parser.getCodec();
+            rootNode = objectMapper.readTree(parser);
+            if (rootNode == null || rootNode.isNull()) {
+                return null;
+            }
+
+            DeserializationConfig config = context.getConfig();
+            JavaType type = TypeFactory.defaultInstance().constructType(clazz);
+            JsonDeserializer<?> defaultDeserializer =
+                    BeanDeserializerFactory.instance.buildBeanDeserializer(
+                            context, type, config.introspect(type));
+
+            if (defaultDeserializer instanceof ResolvableDeserializer) {
+                ((ResolvableDeserializer) defaultDeserializer).resolve(context);
+            }
+
+            JsonParser treeParser = objectMapper.treeAsTokens(rootNode);
+            config.initialize(treeParser);
+
+            if (treeParser.getCurrentToken() == null) {
+                treeParser.nextToken();
+            }
+
+            return (T) defaultDeserializer.deserialize(treeParser, context);
+        } catch (IOException e) {
+            throw JsonMappingException.from(
+                    new TreeTraversingParser(null),
+                    "Error while deserializing object. Some PII fields were redacted. "
+                            + processNode(rootNode, applySensitivity()));
+        }
+    }
+
+    private Predicate<String> applySensitivity() {
+        return sensitiveFields.isEmpty()
+                ? defaultAllFieldsAsSensitive -> allFieldsAreSensitiveOption
+                : sensitiveFields::contains;
+    }
+
+    private JsonNode processNode(JsonNode node, Predicate<String> sensitivityTest) {
+        if (node == null) {
+            return null;
+        }
+        if (node.isArray()) {
+            return processArrayNode(node, sensitivityTest);
+        } else if (node.isObject()) {
+            return processObjectNode((ObjectNode) node, sensitivityTest);
+        } else {
+            return node;
+        }
+    }
+
+    private ArrayNode processArrayNode(JsonNode arrayNode, Predicate<String> sensitivityTest) {
+        ArrayNode newArrayNode = new ArrayNode(JsonNodeFactory.instance);
+
+        for (JsonNode node : arrayNode) {
+            if (node.isValueNode()) {
+                newArrayNode.add(node);
+            } else {
+                newArrayNode.add(processNode(node, sensitivityTest));
+            }
+        }
+
+        return newArrayNode;
+    }
+
+    private ObjectNode processObjectNode(ObjectNode objectNode, Predicate<String> sensitivityTest) {
+        ObjectNode processedNode = objectNode.deepCopy();
+
+        Iterator<Map.Entry<String, JsonNode>> fieldIterator = processedNode.fields();
+        while (fieldIterator.hasNext()) {
+            Map.Entry<String, JsonNode> fieldEntry = fieldIterator.next();
+            String fieldName = fieldEntry.getKey();
+            JsonNode fieldValue = fieldEntry.getValue();
+
+            if (sensitivityTest.test(fieldName)) {
+                redactField(processedNode, fieldName, fieldValue.asText());
+            } else if (fieldValue.isObject()) {
+                // recursively process object nodes
+                processedNode.set(
+                        fieldName, processObjectNode((ObjectNode) fieldValue, sensitivityTest));
+            } else if (fieldValue.isArray()) {
+                // recursively process array nodes
+                processedNode.set(fieldName, processArrayNode(fieldValue, sensitivityTest));
+            }
+        }
+        return processedNode;
+    }
+
+    private void redactField(ObjectNode objectNode, String field, String value) {
+        objectNode.put(field, "*".repeat(value.length() == 0 ? 6 : value.length()));
+    }
+}

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/deserializers/PiiRedactingDeserializerTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/deserializers/PiiRedactingDeserializerTest.java
@@ -1,0 +1,260 @@
+package uk.gov.di.ipv.cri.common.library.util.deserializers;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.DefaultDeserializationContext;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.TreeTraversingParser;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PiiRedactingDeserializerTest {
+    private List<String> sensitiveFields = List.of("id", "name", "email");
+    private ObjectMapper objectMapper;
+
+    @Test
+    void shouldReturnNullWithNullRootNodeWhileAttemptingDeserialization() throws Exception {
+        String json = "null";
+        JsonDeserializer<? extends Person> piiRedactingDeserializer =
+                setUpRedactionModule(
+                        Person.class, () -> new PiiRedactingDeserializer<>(Person.class));
+
+        Object result =
+                piiRedactingDeserializer.deserialize(
+                        jsonParser(json), getDefaultDeserializationContext());
+
+        assertThat(result, nullValue());
+    }
+
+    @Test
+    void shouldNotRedactValidJsonWhenSensitiveFieldsAreNotSpecified() throws IOException {
+        String json =
+                "{\"name\":\"John\",\"email\":\"john.doe@example.com\",\"phone\":\"123456789\",\"city\":\"New York\"}";
+        JsonDeserializer<? extends Person> piiRedactingDeserializer =
+                setUpRedactionModule(
+                        Person.class, () -> new PiiRedactingDeserializer<>(Person.class));
+
+        Person person =
+                piiRedactingDeserializer.deserialize(
+                        jsonParser(json), getDefaultDeserializationContext());
+
+        assertThat(person.getName(), equalTo("John"));
+        assertThat(person.getEmail(), equalTo("john.doe@example.com"));
+        assertThat(person.getPhone(), equalTo("123456789"));
+        assertThat(person.getCity(), equalTo("New York"));
+    }
+
+    @Test
+    void shouldNotRedactValidJsonEvenWhenSensitiveFieldsAreSpecified() throws IOException {
+        String json =
+                "{\"name\":\"John\",\"email\":\"john.doe@example.com\",\"phone\":\"123456789\",\"city\":\"New York\"}";
+        List<String> sensitiveFields = List.of("email", "phone");
+        JsonDeserializer<? extends Person> piiRedactingDeserializer =
+                setUpRedactionModule(
+                        Person.class,
+                        () -> new PiiRedactingDeserializer<>(sensitiveFields, Person.class));
+
+        Person person =
+                piiRedactingDeserializer.deserialize(
+                        jsonParser(json), getDefaultDeserializationContext());
+
+        assertThat(person.getName(), equalTo("John"));
+        assertThat(person.getEmail(), equalTo("john.doe@example.com"));
+        assertThat(person.getPhone(), equalTo("123456789"));
+        assertThat(person.getCity(), equalTo("New York"));
+    }
+
+    @Test
+    void shouldRedactAllFieldsWhenExceptionOccursDuringDeserializationDue() {
+        String inValidJson =
+                "{\"name\":\"John\",\"email\":\"john.doe@example.com\",\"age\":40,\"city\":\"New York\"}";
+        JsonDeserializer<? extends Person> piiRedactingDeserializer =
+                setUpRedactionModule(
+                        Person.class, () -> new PiiRedactingDeserializer<>(Person.class));
+
+        JsonMappingException exception =
+                assertThrows(
+                        JsonMappingException.class,
+                        () ->
+                                piiRedactingDeserializer.deserialize(
+                                        jsonParser(inValidJson),
+                                        getDefaultDeserializationContext()));
+
+        assertThat(
+                exception.getMessage(),
+                containsString(
+                        String.format(
+                                "Error while deserializing object. Some PII fields were redacted. {\"name\":\"%s\",\"email\":\"%s\",\"age\":\"%s\",\"city\":\"%s\"}",
+                                "*".repeat("John".length()),
+                                "*".repeat("john.doe@example.com".length()),
+                                "*".repeat("40".length()),
+                                "*".repeat("New York".length()))));
+    }
+
+    @Test
+    void shouldRedactSpecifiedFieldsWhenExceptionOccursDuringDeserializationDue() {
+        String inValidJson =
+                "{\"name\":\"John\",\"email\":\"john.doe@example.com\",\"age\":40,\"phone\":\"123456789\",\"city\":\"New York\"}";
+        JsonDeserializer<? extends Person> piiRedactingDeserializer =
+                setUpRedactionModule(
+                        Person.class,
+                        () -> new PiiRedactingDeserializer<>(sensitiveFields, Person.class));
+
+        JsonMappingException exception =
+                assertThrows(
+                        JsonMappingException.class,
+                        () ->
+                                piiRedactingDeserializer.deserialize(
+                                        jsonParser(inValidJson),
+                                        getDefaultDeserializationContext()));
+
+        assertThat(
+                exception.getMessage(),
+                containsString(
+                        String.format(
+                                "Error while deserializing object. Some PII fields were redacted. {\"name\":\"%s\",\"email\":\"%s\",\"age\":%d,\"phone\":\"%s\",\"city\":\"%s\"}",
+                                "*".repeat("John".length()),
+                                "*".repeat("john.doe@example.com".length()),
+                                40,
+                                "123456789",
+                                "New York")));
+    }
+
+    @Test
+    void shouldRedactFieldsInNestedObjects() {
+        List<String> sensitiveFields = List.of("firstName", "lastName", "date");
+        String InvalidNestedJson =
+                "{\"name\":[{\"firstName\":\"John\",\"lastName\":\"Doe\"}],\"birthDate\":[{\"date\":\"1980-00-00\",\"place\":\"London\"}],\"address\":[{\"addressLine1\":\"123 Main St\",\"addressLine2\":\"\",\"city\":\"London\",\"postcode\":\"SW1A 1AA\",\"countryCode\":\"GB\"}],\"drivingPermit\":[{\"number\":\"AB12345\",\"type\":\"CAR\",\"expiryDate\":\"2023-00-00\"}]}";
+        JsonDeserializer<? extends PersonIdentityDetailed> piiRedactingDeserializer =
+                setUpRedactionModule(
+                        PersonIdentityDetailed.class,
+                        () ->
+                                new PiiRedactingDeserializer<>(
+                                        sensitiveFields, PersonIdentityDetailed.class));
+
+        JsonMappingException exception =
+                assertThrows(
+                        JsonMappingException.class,
+                        () ->
+                                piiRedactingDeserializer.deserialize(
+                                        jsonParser(InvalidNestedJson),
+                                        getDefaultDeserializationContext()));
+
+        assertThat(
+                exception.getMessage(),
+                containsString(
+                        String.format(
+                                "Error while deserializing object. Some PII fields were redacted. {\"name\":[{\"firstName\":\"%s\",\"lastName\":\"%s\"}],\"birthDate\":[{\"date\":\"%s\",\"place\":\"London\"}],\"address\":[{\"addressLine1\":\"123 Main St\",\"addressLine2\":\"\",\"city\":\"London\",\"postcode\":\"SW1A 1AA\",\"countryCode\":\"GB\"}],\"drivingPermit\":[{\"number\":\"AB12345\",\"type\":\"CAR\",\"expiryDate\":\"2023-00-00\"}]}",
+                                "*".repeat("John".length()),
+                                "*".repeat("Doe".length()),
+                                "*".repeat("1980-00-00".length()))));
+    }
+
+    @Test
+    void shouldRedactArrayFieldsWithEmptyString() {
+        List<String> sensitiveFields = List.of("name", "address", "drivingPermit");
+        String InvalidNestedJson =
+                "{\"name\":[{\"firstName\":\"John\",\"lastName\":\"Doe\"}],\"birthDate\":[{\"date\":\"1980-00-00\",\"place\":\"London\"}],\"address\":[{\"addressLine1\":\"123 Main St\",\"addressLine2\":\"\",\"city\":\"London\",\"postcode\":\"SW1A 1AA\",\"countryCode\":\"GB\"}],\"drivingPermit\":[{\"number\":\"AB12345\",\"type\":\"CAR\",\"expiryDate\":\"2023-00-00\"}]}";
+        JsonDeserializer<? extends PersonIdentityDetailed> piiRedactingDeserializer =
+                setUpRedactionModule(
+                        PersonIdentityDetailed.class,
+                        () ->
+                                new PiiRedactingDeserializer<>(
+                                        sensitiveFields, PersonIdentityDetailed.class));
+
+        JsonMappingException exception =
+                assertThrows(
+                        JsonMappingException.class,
+                        () ->
+                                piiRedactingDeserializer.deserialize(
+                                        jsonParser(InvalidNestedJson),
+                                        getDefaultDeserializationContext()));
+
+        assertThat(
+                exception.getMessage(),
+                containsString(
+                        String.format(
+                                "Error while deserializing object. Some PII fields were redacted. {\"name\":\"%s\",\"birthDate\":[{\"date\":\"1980-00-00\",\"place\":\"London\"}],\"address\":\"%s\",\"drivingPermit\":\"%s\"}",
+                                "*".repeat(6), "*".repeat(6), "*".repeat(6))));
+    }
+
+    private JsonParser jsonParser(String json) throws IOException {
+        return objectMapper.getFactory().createParser(json);
+    }
+
+    private DefaultDeserializationContext getDefaultDeserializationContext() {
+        JsonNode nullNode = objectMapper.getNodeFactory().nullNode();
+        JsonParser nullParser = new TreeTraversingParser(nullNode);
+        DeserializationConfig config = objectMapper.getDeserializationConfig();
+
+        DefaultDeserializationContext context =
+                new DefaultDeserializationContext.Impl(
+                        objectMapper.getDeserializationContext().getFactory());
+        context = context.createInstance(config, nullParser, objectMapper.getInjectableValues());
+        return context;
+    }
+
+    private <T> JsonDeserializer<? extends T> setUpRedactionModule(
+            Class<T> clazz, Supplier<JsonDeserializer<? extends T>> deserializerSupplier) {
+        JsonDeserializer<? extends T> deserializer = deserializerSupplier.get();
+        SimpleModule redactionModule = new SimpleModule();
+        redactionModule.addDeserializer(clazz, deserializer);
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule()).registerModule(redactionModule);
+        return deserializer;
+    }
+
+    static class Person {
+        private String name;
+        private String email;
+        private String phone;
+        private String city;
+
+        String getName() {
+            return name;
+        }
+
+        void setName(String name) {
+            this.name = name;
+        }
+
+        String getEmail() {
+            return email;
+        }
+
+        void setEmail(String email) {
+            this.email = email;
+        }
+
+        String getPhone() {
+            return phone;
+        }
+
+        void setPhone(String phone) {
+            this.phone = phone;
+        }
+
+        String getCity() {
+            return city;
+        }
+
+        void setCity(String city) {
+            this.city = city;
+        }
+    }
+}


### PR DESCRIPTION
## Overview

The code redacts sensitive fields when an error occurs parsing Json. Use this by registering with objectMapper

```
        SimpleModule redactionModule = new SimpleModule();
        this.objectMapper = new ObjectMapper();
        redactionModule.addDeserializer(
                SharedClaims.class,
                new PiiRedactingDeserializer<>(sensitiveFields, SharedClaims.class));
        objectMapper
                .registerModule(redactionModule)
```

## Proposed changes

On rare ocassions an error can occur during JSON parsing for example in the SharedClaim above, these errors are thrown to the [EventProbe](https://github.com/alphagov/di-ipv-cri-lib/blob/main/src/main/java/uk/gov/di/ipv/cri/common/library/util/EventProbe.java#L36) this could result in PII leakage. This PR introduces an objectMapper module that intercepts the deserialization process when an error occurs and redacts fields that are specified explicitly 

```
    private final List<String> sensitiveFields = List.of("name", "birthDate", "address");

```

```
new PiiRedactingDeserializer<>(sensitiveFields, SharedClaims.class));
```

Would redact the specified field values from the payload


or when not specified explicitly

```
new PiiRedactingDeserializer<>(SharedClaims.class));
```

Would redact all fields values of the payload in the error message

```
Error while deserializing object. Some PII fields were redacted. {\"@context\":[\"https://www.w3.org/2018/credentials/v1\",\"https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld\"],\"name\":\"******\",\"birthDate\":\"******\",\"address\":\"******\"}"
```


### Why did it change

Related to https://govukverify.atlassian.net/browse/OJ-1316 this code provides further mitigation that can be used by other CRI's as well

### Issue tracking

- [OJ-1305](https://govukverify.atlassian.net/browse/OJ-1305)


[OJ-1305]: https://govukverify.atlassian.net/browse/OJ-1305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ