### PR TITLE
Oj1313: removed vc expiry in the common claimset builder

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 1.4.4
+
+* Added feature release flag for VC expiry
+
 ## 1.4.3
 
 * Added `PiiRedactingDeserializer`

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "1.4.3"
+def buildVersion = "1.4.4"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 


### PR DESCRIPTION
## Proposed changes

see: https://govukverify.atlassian.net/browse/OJ-1313

### What changed

The inclusion of expiry date on the VC is can be optionally engaged or switched off

### Why did it change

Decison to implement time-based identity check validity policy based (in the first place) on issuance dates, rather than hard-coded expiry dates in verifiable credentials (VCs). This decision is recorded in [ADR 76 (VC lifetime)](https://github.com/alphagov/digital-identity-architecture/blob/main/adr/0076-vc-lifetime.md).

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1313](https://govukverify.atlassian.net/browse/OJ-1313)

## Checklists

### Environment variables or secrets
- /release-flags/vc-expiry-removed

- [ ] Release note updated in the [RELEASE](./blob/main/RELEASE.md)


[OJ-1313]: https://govukverify.atlassian.net/browse/OJ-1313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ