### PR TITLE
LIME-534 - Update TxMA audit events.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 1.4.6
+
+* Added `IPV_PASSPORT_` audit events.
+
 ## 1.4.5
 
 * Modified feature release flag for VC expiry

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "1.4.5"
+def buildVersion = "1.4.6"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEventType.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/domain/AuditEventType.java
@@ -6,6 +6,13 @@ public enum AuditEventType {
     REQUEST_SENT, // When a third party call is started
     VC_ISSUED, // When the final VC is created in the issue credential lambda
     THIRD_PARTY_REQUEST_ENDED, // When a third party requests are ended
-    END, // When VC credentials are being returned - final event
     RESPONSE_RECEIVED, // This is to replace THIRD_PARTY_REQUEST_ENDED
+    END, // When VC credentials are being returned - final event
+
+    // Passport-related
+    IPV_PASSPORT_CRI_START, // Before a passport session is written to the Session table
+    IPV_PASSPORT_CRI_REQUEST_SENT, // When a passport request call is started
+    IPV_PASSPORT_CRI_VC_ISSUED, // When the final passport VC is issued
+    IPV_PASSPORT_CRI_RESPONSE_RECEIVED, // When a third party passport request is ended
+    IPV_PASSPORT_CRI_END // When VC credentials are being returned - final passport event
 }


### PR DESCRIPTION
## Proposed changes

### What changed

- Added audit events for Passport CRI.

### Why did it change

- Support for the Passport CRI refactor / replacement.

### Issue tracking

- [LIME-534](https://govukverify.atlassian.net/browse/LIME-534)

[LIME-534]: https://govukverify.atlassian.net/browse/LIME-534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ