### PR TITLE
OJ-1522: added default client id

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 1.4.6
+
+* Add default client id representing core stub
+
 ## 1.4.5
 
 * Modified feature release flag for VC expiry

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "1.4.5"
+def buildVersion = "1.4.6"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/ClientConfigurationService.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/ClientConfigurationService.java
@@ -56,7 +56,8 @@ public class ClientConfigurationService {
                         System.getenv("IPV_CORE_STUB_CRI_ID"),
                         String.format(
                                 MISSING_ENV_VARIABLE_ERROR_MSG_FORMAT, "IPV_CORE_STUB_CRI_ID"));
-        this.ipvCoreStubClientId = Optional.ofNullable(System.getenv("DEFAULT_CLIENT_ID")).orElse("ipv-core-stub");
+        this.ipvCoreStubClientId =
+                Optional.ofNullable(System.getenv("DEFAULT_CLIENT_ID")).orElse("ipv-core-stub");
     }
 
     public String getPrivateApiEndpoint() {
@@ -86,7 +87,10 @@ public class ClientConfigurationService {
     public String getIpvCoreStubCriId() {
         return ipvCoreStubCriId;
     }
-    public String getDefaultClientId() { return this.ipvCoreStubClientId; }
+
+    public String getDefaultClientId() {
+        return this.ipvCoreStubClientId;
+    }
 
     public String createUriPath(String endpoint) {
         return String.format("/%s/%s", this.environment, endpoint);

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/ClientConfigurationService.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/ClientConfigurationService.java
@@ -14,6 +14,7 @@ public class ClientConfigurationService {
     private final String ipvCoreStubUsername;
     private final String ipvCoreStubPassword;
     private final String ipvCoreStubCriId;
+    private final String ipvCoreStubClientId;
 
     public ClientConfigurationService() {
         this.environment =
@@ -55,6 +56,7 @@ public class ClientConfigurationService {
                         System.getenv("IPV_CORE_STUB_CRI_ID"),
                         String.format(
                                 MISSING_ENV_VARIABLE_ERROR_MSG_FORMAT, "IPV_CORE_STUB_CRI_ID"));
+        this.ipvCoreStubClientId = Optional.ofNullable(System.getenv("DEFAULT_CLIENT_ID")).orElse("ipv-core-stub");
     }
 
     public String getPrivateApiEndpoint() {
@@ -84,6 +86,7 @@ public class ClientConfigurationService {
     public String getIpvCoreStubCriId() {
         return ipvCoreStubCriId;
     }
+    public String getDefaultClientId() { return this.ipvCoreStubClientId; }
 
     public String createUriPath(String endpoint) {
         return String.format("/%s/%s", this.environment, endpoint);

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/CommonApiClient.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/CommonApiClient.java
@@ -30,7 +30,8 @@ public class CommonApiClient {
                                         .setPath("/callback")
                                         .build()
                                         .toString())
-                        .addParameter("client_id", this.clientConfigurationService.getDefaultClientId())
+                        .addParameter(
+                                "client_id", this.clientConfigurationService.getDefaultClientId())
                         .addParameter("response_type", "code")
                         .addParameter("scope", "openid")
                         .addParameter("state", "state-ipv")

--- a/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/CommonApiClient.java
+++ b/src/testFixtures/java/uk/gov/di/ipv/cri/common/library/client/CommonApiClient.java
@@ -30,7 +30,7 @@ public class CommonApiClient {
                                         .setPath("/callback")
                                         .build()
                                         .toString())
-                        .addParameter("client_id", "ipv-core-stub")
+                        .addParameter("client_id", this.clientConfigurationService.getDefaultClientId())
                         .addParameter("response_type", "code")
                         .addParameter("scope", "openid")
                         .addParameter("state", "state-ipv")


### PR DESCRIPTION
## Proposed changes

Facilitate the ability to be able to run the command https://github.com/alphagov/di-ipv-cri-kbv-api#run-integration-tests by changing IPV_CORE_STUB_URL to point to the new aws stub url i.e. https://di-ipv-core-stub.london.cloudapps.digital/

doing this would make it easier to know what needs to be added when amending corresponding https://github.com/alphagov/di-ipv-cri-kbv-api/blob/main/.github/workflows/pre-merge-integration-test.yml

### What changed

Added a `ipvCoreStubClientId` which allows overriding the stub id from `ipv-core-stub`

### Why did it change

The move from PAAS to AWS introduces a new stub Id `ipv-stub-core-aws-build` or `ipv-stub-core-aws-prod`
depending on the environment


- [OJ-1522](https://govukverify.atlassian.net/browse/OJ-1522)


### Environment variables

New Environment variable `DEFAULT_CLIENT_ID`

### Other considerations

Consumers such as (KBV or ADDRESS) CRI would be able to run a command such as:

```
 ENVIRONMENT=*** STACK_NAME=**** IPV_CORE_STUB_CRI_ID=*** API_GATEWAY_ID_PRIVATE=*** API_GATEWAY_ID_PUBLIC=*** IPV_CORE_STUB_BASIC_AUTH_USER=*** IPV_CORE_STUB_BASIC_AUTH_PASSWORD=**** IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" DEFAULT_CLIENT_ID=ipv-core-stub-aws-build APIGW_API_KEY=**** gradle integration-tests:cucumber
```          



- [ ] Updated [RELEASE_NOTES.MD](./blob/main/RELEASE_NOTES.md) 

[OJ-1522]: https://govukverify.atlassian.net/browse/OJ-1522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ