### PR TITLE
OJ-1422: add unique id to vc

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Credential Issuer common libraries Release Notes
 
+## 1.5.1
+
+* Added a UUID id to `VerifiableCredentialClaimsSetBuilder` ensuring the Claimset of the Verifiable Credential (VC) contains a unique identifier which allows VC's to distinguish each other
+
 ## 1.5.0
 
 * Added new factory object `PersonIdentityDetailedFactory` with `createPersonIdentityDetailedWith` methods for creation of `PersonIdentityDetailed` with cri specific lists to restrict scope of any PersonIdentityDetailed constructor changes to just cri-lib

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "1.5.0"
+def buildVersion = "1.5.1"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilder.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilder.java
@@ -13,6 +13,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 
 public class VerifiableCredentialClaimsSetBuilder {
     private final ConfigurationService configurationService;
@@ -25,11 +26,17 @@ public class VerifiableCredentialClaimsSetBuilder {
     private Object evidence;
     private ChronoUnit ttlUnit;
     private long ttl;
+    private String id;
 
     public VerifiableCredentialClaimsSetBuilder(
             ConfigurationService configurationService, Clock clock) {
         this.configurationService = configurationService;
         this.clock = clock;
+    }
+
+    public VerifiableCredentialClaimsSetBuilder id(UUID uniqueId) {
+        this.id = generateUniqueId(uniqueId);
+        return this;
     }
 
     public VerifiableCredentialClaimsSetBuilder subject(String subject) {
@@ -109,6 +116,10 @@ public class VerifiableCredentialClaimsSetBuilder {
         Map<String, Object> verifiableCredentialClaims = new LinkedHashMap<>();
         verifiableCredentialClaims.put(
                 "type", new String[] {"VerifiableCredential", this.verifiableCredentialType});
+
+        if (isReleaseFlag("/release-flags/vc-contains-unique-id")) {
+            verifiableCredentialClaims.put("id", this.id);
+        }
         if (Objects.nonNull(this.contexts) && contexts.length > 0) {
             verifiableCredentialClaims.put("@context", contexts);
         }
@@ -153,5 +164,10 @@ public class VerifiableCredentialClaimsSetBuilder {
                 throw new IllegalStateException(
                         "Unexpected time-to-live unit encountered: " + ttlUnit);
         }
+    }
+
+    private String generateUniqueId(UUID uniqueId) {
+        return String.format(
+                "urn:uuid:%s", Objects.requireNonNull(uniqueId, "UniqueId must not be null"));
     }
 }

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilder.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilder.java
@@ -18,7 +18,7 @@ import java.util.function.UnaryOperator;
 
 public class VerifiableCredentialClaimsSetBuilder {
     private static final String EXPIRY_REMOVED = "/release-flags/vc-expiry-removed";
-    private static final String CONTAINS_UNIQUE_ID = "/release-flags/vc-contains-unique-id";
+    private static final String CONTAINS_UNIQUE_ID = "release-flags/vc-contains-unique-id";
     private final ConfigurationService configurationService;
     private final Clock clock;
 
@@ -29,17 +29,11 @@ public class VerifiableCredentialClaimsSetBuilder {
     private Object evidence;
     private ChronoUnit ttlUnit;
     private long ttl;
-    private String id;
 
     public VerifiableCredentialClaimsSetBuilder(
             ConfigurationService configurationService, Clock clock) {
         this.configurationService = configurationService;
         this.clock = clock;
-    }
-
-    public VerifiableCredentialClaimsSetBuilder id(UUID uniqueId) {
-        this.id = generateUniqueId(uniqueId);
-        return this;
     }
 
     public VerifiableCredentialClaimsSetBuilder subject(String subject) {
@@ -121,7 +115,7 @@ public class VerifiableCredentialClaimsSetBuilder {
                 "type", new String[] {"VerifiableCredential", this.verifiableCredentialType});
 
         if (isReleaseFlag(configurationService::getParameterValue, CONTAINS_UNIQUE_ID)) {
-            verifiableCredentialClaims.put("id", this.id);
+            verifiableCredentialClaims.put("id", generateUniqueId());
         }
         if (Objects.nonNull(this.contexts) && contexts.length > 0) {
             verifiableCredentialClaims.put("@context", contexts);
@@ -167,8 +161,7 @@ public class VerifiableCredentialClaimsSetBuilder {
         }
     }
 
-    private String generateUniqueId(UUID uniqueId) {
-        return String.format(
-                "urn:uuid:%s", Objects.requireNonNull(uniqueId, "UniqueId must not be null"));
+    private String generateUniqueId() {
+        return String.format("urn:uuid:%s", UUID.randomUUID());
     }
 }

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilderTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilderTest.java
@@ -188,7 +188,7 @@ class VerifiableCredentialClaimsSetBuilderTest {
                         "/release-flags/vc-expiry-removed"))
                 .thenReturn(expiryRemovedReleasedFlagValue);
 
-        when(mockConfigurationService.getParameterValue("/release-flags/vc-contains-unique-id"))
+        when(mockConfigurationService.getParameterValue("release-flags/vc-contains-unique-id"))
                 .thenThrow(ParameterNotFoundException.class);
 
         JWTClaimsSet builtClaimSet =
@@ -225,19 +225,17 @@ class VerifiableCredentialClaimsSetBuilderTest {
             String expiryRemovedReleasedFlagValue) throws ParseException {
         String[] testContexts = new String[] {"context1", "context2"};
         Map<String, String> evidence = Collections.emptyMap();
-        UUID fixedUuid = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
 
         when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(TEST_ISSUER);
         when(mockConfigurationService.getParameterValueByAbsoluteName(
                         "/release-flags/vc-expiry-removed"))
                 .thenReturn(expiryRemovedReleasedFlagValue);
 
-        when(mockConfigurationService.getParameterValue("/release-flags/vc-contains-unique-id"))
+        when(mockConfigurationService.getParameterValue("release-flags/vc-contains-unique-id"))
                 .thenReturn("true");
 
         JWTClaimsSet builtClaimSet =
                 this.builder
-                        .id(fixedUuid)
                         .subject(TEST_SUBJECT)
                         .timeToLive(6L, ChronoUnit.MONTHS)
                         .verifiableCredentialType(TEST_VC_TYPE)
@@ -260,9 +258,9 @@ class VerifiableCredentialClaimsSetBuilderTest {
                 (String[]) builtClaimSet.getJSONObjectClaim("vc").get("type"));
         assertEquals(testContexts, builtClaimSet.getJSONObjectClaim("vc").get("@context"));
         assertEquals(evidence, builtClaimSet.getJSONObjectClaim("vc").get("evidence"));
-        assertEquals(
-                "urn:uuid:123e4567-e89b-12d3-a456-426614174000",
-                builtClaimSet.getJSONObjectClaim("vc").get("id"));
+        assertNotNull(builtClaimSet.getJSONObjectClaim("vc").get("id"));
+        assertTrue(
+                builtClaimSet.getJSONObjectClaim("vc").get("id").toString().contains("urn:uuid:"));
     }
 
     @Test
@@ -328,13 +326,6 @@ class VerifiableCredentialClaimsSetBuilderTest {
                 assertThrows(IllegalStateException.class, () -> this.builder.build());
         assertEquals(
                 "The verifiable credential type must be specified", thrownException.getMessage());
-    }
-
-    @Test
-    void shouldThrowErrorWhenNoUniqueIdIsSupplied() {
-        NullPointerException thrownException =
-                assertThrows(NullPointerException.class, () -> this.builder.id(null));
-        assertEquals("UniqueId must not be null", thrownException.getMessage());
     }
 
     @Test

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilderTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilderTest.java
@@ -20,6 +20,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 
@@ -53,7 +54,7 @@ class VerifiableCredentialClaimsSetBuilderTest {
     }
 
     @Test
-    void shouldBuildVerifiableCredentialWithoutWhenReleaseFlagIsNotSpecified()
+    void shouldBuildVerifiableCredentialWhenVcExpiryRemovedReleaseFlagIsNotSpecified()
             throws ParseException {
         String[] testContexts = new String[] {"context1", "context2"};
         Map<String, String> evidence =
@@ -95,13 +96,7 @@ class VerifiableCredentialClaimsSetBuilderTest {
 
     @ParameterizedTest
     @NullSource
-    @ValueSource(
-            strings = {
-                "",
-                " ",
-                "false",
-                "anything",
-            })
+    @ValueSource(strings = {"", " ", "false", "anything"})
     void shouldBuildVerifiableCredential(String expiryRemovedReleasedFlagValue)
             throws ParseException {
         String[] testContexts = new String[] {"context1", "context2"};
@@ -180,6 +175,98 @@ class VerifiableCredentialClaimsSetBuilderTest {
         assertNull(builtClaimSet.getLongClaim(EXPIRATION_TIME));
     }
 
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", " ", "false", "anything"})
+    void shouldBuildVerifiableCredentialWhenVcContainsUniqueIdReleaseFlagIsNotSpecified(
+            String expiryRemovedReleasedFlagValue) throws ParseException {
+        String[] testContexts = new String[] {"context1", "context2"};
+        Map<String, String> evidence = Collections.emptyMap();
+
+        when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(TEST_ISSUER);
+        when(mockConfigurationService.getParameterValueByAbsoluteName(
+                        "/release-flags/vc-expiry-removed"))
+                .thenReturn(expiryRemovedReleasedFlagValue);
+
+        when(mockConfigurationService.getParameterValueByAbsoluteName(
+                        "/release-flags/vc-contains-unique-id"))
+                .thenThrow(ParameterNotFoundException.class);
+
+        JWTClaimsSet builtClaimSet =
+                this.builder
+                        .subject(TEST_SUBJECT)
+                        .timeToLive(6L, ChronoUnit.MONTHS)
+                        .verifiableCredentialType(TEST_VC_TYPE)
+                        .verifiableCredentialSubject(TEST_PERSON_IDENTITY)
+                        .verifiableCredentialContext(testContexts)
+                        .verifiableCredentialEvidence(evidence)
+                        .build();
+
+        assertNotNull(builtClaimSet);
+        assertEquals(TEST_SUBJECT, builtClaimSet.getSubject());
+        assertEquals(TEST_ISSUER, builtClaimSet.getIssuer());
+        assertEquals(this.clock.instant().getEpochSecond(), builtClaimSet.getLongClaim(NOT_BEFORE));
+        assertTrue(
+                builtClaimSet.getLongClaim(EXPIRATION_TIME)
+                        > this.clock.instant().getEpochSecond());
+        assertEquals(
+                TEST_PERSON_IDENTITY,
+                builtClaimSet.getJSONObjectClaim("vc").get("credentialSubject"));
+        assertArrayEquals(
+                new String[] {"VerifiableCredential", TEST_VC_TYPE},
+                (String[]) builtClaimSet.getJSONObjectClaim("vc").get("type"));
+        assertEquals(testContexts, builtClaimSet.getJSONObjectClaim("vc").get("@context"));
+        assertEquals(evidence, builtClaimSet.getJSONObjectClaim("vc").get("evidence"));
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", " ", "false", "anything"})
+    void shouldBuildVerifiableCredentialWhenVcContainsUniqueIdReleaseFlagIsSpecified(
+            String expiryRemovedReleasedFlagValue) throws ParseException {
+        String[] testContexts = new String[] {"context1", "context2"};
+        Map<String, String> evidence = Collections.emptyMap();
+        UUID fixedUuid = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+
+        when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(TEST_ISSUER);
+        when(mockConfigurationService.getParameterValueByAbsoluteName(
+                        "/release-flags/vc-expiry-removed"))
+                .thenReturn(expiryRemovedReleasedFlagValue);
+
+        when(mockConfigurationService.getParameterValueByAbsoluteName(
+                        "/release-flags/vc-contains-unique-id"))
+                .thenReturn("true");
+
+        JWTClaimsSet builtClaimSet =
+                this.builder
+                        .id(fixedUuid)
+                        .subject(TEST_SUBJECT)
+                        .timeToLive(6L, ChronoUnit.MONTHS)
+                        .verifiableCredentialType(TEST_VC_TYPE)
+                        .verifiableCredentialSubject(TEST_PERSON_IDENTITY)
+                        .verifiableCredentialContext(testContexts)
+                        .verifiableCredentialEvidence(evidence)
+                        .build();
+
+        assertEquals(TEST_SUBJECT, builtClaimSet.getSubject());
+        assertEquals(TEST_ISSUER, builtClaimSet.getIssuer());
+        assertEquals(this.clock.instant().getEpochSecond(), builtClaimSet.getLongClaim(NOT_BEFORE));
+        assertTrue(
+                builtClaimSet.getLongClaim(EXPIRATION_TIME)
+                        > this.clock.instant().getEpochSecond());
+        assertEquals(
+                TEST_PERSON_IDENTITY,
+                builtClaimSet.getJSONObjectClaim("vc").get("credentialSubject"));
+        assertArrayEquals(
+                new String[] {"VerifiableCredential", TEST_VC_TYPE},
+                (String[]) builtClaimSet.getJSONObjectClaim("vc").get("type"));
+        assertEquals(testContexts, builtClaimSet.getJSONObjectClaim("vc").get("@context"));
+        assertEquals(evidence, builtClaimSet.getJSONObjectClaim("vc").get("evidence"));
+        assertEquals(
+                "urn:uuid:123e4567-e89b-12d3-a456-426614174000",
+                builtClaimSet.getJSONObjectClaim("vc").get("id"));
+    }
+
     @Test
     void shouldBuildVerifiableCredentialWithoutContextAndEvidence() throws ParseException {
         when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(TEST_ISSUER);
@@ -243,6 +330,13 @@ class VerifiableCredentialClaimsSetBuilderTest {
                 assertThrows(IllegalStateException.class, () -> this.builder.build());
         assertEquals(
                 "The verifiable credential type must be specified", thrownException.getMessage());
+    }
+
+    @Test
+    void shouldThrowErrorWhenNoUniqueIdIsSupplied() {
+        NullPointerException thrownException =
+                assertThrows(NullPointerException.class, () -> this.builder.id(null));
+        assertEquals("UniqueId must not be null", thrownException.getMessage());
     }
 
     @Test

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilderTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilderTest.java
@@ -188,8 +188,7 @@ class VerifiableCredentialClaimsSetBuilderTest {
                         "/release-flags/vc-expiry-removed"))
                 .thenReturn(expiryRemovedReleasedFlagValue);
 
-        when(mockConfigurationService.getParameterValueByAbsoluteName(
-                        "/release-flags/vc-contains-unique-id"))
+        when(mockConfigurationService.getParameterValue("/release-flags/vc-contains-unique-id"))
                 .thenThrow(ParameterNotFoundException.class);
 
         JWTClaimsSet builtClaimSet =
@@ -233,8 +232,7 @@ class VerifiableCredentialClaimsSetBuilderTest {
                         "/release-flags/vc-expiry-removed"))
                 .thenReturn(expiryRemovedReleasedFlagValue);
 
-        when(mockConfigurationService.getParameterValueByAbsoluteName(
-                        "/release-flags/vc-contains-unique-id"))
+        when(mockConfigurationService.getParameterValue("/release-flags/vc-contains-unique-id"))
                 .thenReturn("true");
 
         JWTClaimsSet builtClaimSet =


### PR DESCRIPTION
## Proposed changes

Added id field to VerifiableCredentialClaimsSetBuilder which will require VeriableCredential issuers to specify a UUID

### What changed

logic is introduced via a `release_flag` which involves checking for the presence and of the value of `/release-flags/vc-contains-unique-id` contains "true" if the release above release flag is not present or is any other value it returns false.
Implying VC have not yet enabled to the feature flag to include unique id

### Why did it change

https://github.com/alphagov/digital-identity-architecture/blob/main/adr/0079-unique-identifier-for-verifiable-credential.md#option-6---preferred-optionIn order to be able to distinguish one Verifiable Credential (VC) from another VC it will be necessary for VCs to be able to be uniquely identifiable

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1422](https://govukverify.atlassian.net/browse/OJ-1422)

## Checklists

### Environment variables or secrets


### Other considerations

- [ ] Updated [RELEASE.MD](./blob/main/RELEASE.md) with any new instructions or tasks

[OJ-1422]: https://govukverify.atlassian.net/browse/OJ-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ