### PR TITLE
Oj-1422: add jti to vc using uniqueuuid

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Credential Issuer common libraries Release Notes
 
+## 1.5.2
+
+* Fix for the below, add UUID id to `VerifiableCredentialClaimsSetBuilder` as a top level attribute `jti` of the `jwt` 
+
+
 ## 1.5.1
 
 * Added a UUID id to `VerifiableCredentialClaimsSetBuilder` ensuring the Claimset of the Verifiable Credential (VC) contains a unique identifier which allows VC's to distinguish each other

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 // please update RELEASE_NOTES.md when you update this version
-def buildVersion = "1.5.1"
+def buildVersion = "1.5.2"
 
 defaultTasks 'clean', 'spotlessApply', 'build'
 

--- a/src/main/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilder.java
+++ b/src/main/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilder.java
@@ -115,7 +115,7 @@ public class VerifiableCredentialClaimsSetBuilder {
                 "type", new String[] {"VerifiableCredential", this.verifiableCredentialType});
 
         if (isReleaseFlag(configurationService::getParameterValue, CONTAINS_UNIQUE_ID)) {
-            verifiableCredentialClaims.put("id", generateUniqueId());
+            builder.claim(JWTClaimNames.JWT_ID, generateUniqueId());
         }
         if (Objects.nonNull(this.contexts) && contexts.length > 0) {
             verifiableCredentialClaims.put("@context", contexts);

--- a/src/test/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilderTest.java
+++ b/src/test/java/uk/gov/di/ipv/cri/common/library/util/VerifiableCredentialClaimsSetBuilderTest.java
@@ -258,9 +258,21 @@ class VerifiableCredentialClaimsSetBuilderTest {
                 (String[]) builtClaimSet.getJSONObjectClaim("vc").get("type"));
         assertEquals(testContexts, builtClaimSet.getJSONObjectClaim("vc").get("@context"));
         assertEquals(evidence, builtClaimSet.getJSONObjectClaim("vc").get("evidence"));
-        assertNotNull(builtClaimSet.getJSONObjectClaim("vc").get("id"));
-        assertTrue(
-                builtClaimSet.getJSONObjectClaim("vc").get("id").toString().contains("urn:uuid:"));
+        assertNotNull(builtClaimSet.getJWTID());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> getUuidString("urn:uuid:this-does-not-look-like-a-uuid"));
+        assertTrue(builtClaimSet.getJWTID().contains("urn:uuid:"));
+        assertJWTClaimsSetContainsAnIdentifierSimilarToAUuid(builtClaimSet);
+    }
+
+    private static void assertJWTClaimsSetContainsAnIdentifierSimilarToAUuid(
+            JWTClaimsSet builtClaimSet) {
+        assertTrue(builtClaimSet.getJWTID().contains(getUuidString(builtClaimSet.getJWTID())));
+    }
+
+    private static String getUuidString(String jwtId) {
+        return UUID.fromString(jwtId.split(":")[2]).toString();
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

Fix for previous [PR](https://github.com/alphagov/di-ipv-cri-lib/pull/244) two things were wrong

- The `id` is a to level attritube of the `jwt` not inside the `vc` element
- The name is `jti` and not `id`

### What changed

see: https://github.com/alphagov/digital-identity-architecture/blob/7c90be0db85a3a3093c766d845d5f278a3d86e16/rfc/0045-claimed-identity-cri.md?plain=1#L217

### Why did it change

Miss-intepretation of the indentifier [JSON-LD ](https://www.w3.org/TR/vc-data-model/#example-a-relationship-credential-issued-by-a-child)refers to identifier as `id` whereas when verifiable-credential are expressed as [jwt](https://www.w3.org/TR/vc-data-model/#example-jwt-payload-of-a-jwt-based-verifiable-credential-using-jws-as-a-proof-non-normative) the id is referred to as `jti` 

### Issue tracking

- [OJ-1422](https://govukverify.atlassian.net/browse/OJ-1422)

### Other considerations

- [ ] Update [RELEASE_NOTES](./blob/main/RELEASE_NOTES.md) with any new instructions or tasks

[OJ-1422]: https://govukverify.atlassian.net/browse/OJ-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ